### PR TITLE
Implement RNA-seq data fetching tool with FastAPI and gget integration

### DIFF
--- a/biomni_mcp_tools/get_rna_seq_archs4/__init__.py
+++ b/biomni_mcp_tools/get_rna_seq_archs4/__init__.py
@@ -1,0 +1,1 @@
+# Biomni MCP get_rna_seq_archs4 package marker

--- a/biomni_mcp_tools/get_rna_seq_archs4/main.py
+++ b/biomni_mcp_tools/get_rna_seq_archs4/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from fastapi import FastAPI
+from pydantic import BaseModel
+from biomni_mcp_tools.get_rna_seq_archs4.tool import get_rna_seq_archs4
+
+app = FastAPI()
+
+class Input(BaseModel):
+    gene_name: str
+    K: int = 10
+
+@app.post("/get_rna_seq_archs4")
+async def run_tool(input: Input):
+    result = get_rna_seq_archs4(input.gene_name, input.K)
+    return {"result": result}

--- a/biomni_mcp_tools/get_rna_seq_archs4/requirements.txt
+++ b/biomni_mcp_tools/get_rna_seq_archs4/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+gget
+pandas

--- a/biomni_mcp_tools/get_rna_seq_archs4/test_client.py
+++ b/biomni_mcp_tools/get_rna_seq_archs4/test_client.py
@@ -1,0 +1,12 @@
+import requests
+
+# Replace "TP53" and 5 with own values if needed
+payload = {
+    "gene_name": "TP53",
+    "K": 5
+}
+
+response = requests.post("http://localhost:5090/get_rna_seq_archs4", json=payload)
+
+print("Status code:", response.status_code)
+print("Response:", response.json())

--- a/biomni_mcp_tools/get_rna_seq_archs4/tool.py
+++ b/biomni_mcp_tools/get_rna_seq_archs4/tool.py
@@ -1,0 +1,20 @@
+import gget
+
+def get_rna_seq_archs4(gene_name: str, K: int = 10) -> dict:
+    """Fetch RNA-seq expression for a gene from ARCHS4, returning top K tissues by median TPM."""
+    result = {"gene_name": gene_name, "K": K, "tissues": [], "log": ""}
+    try:
+        result["log"] += f"Fetching RNA-seq data using gget.archs4 for gene: {gene_name}...\n"
+        data = gget.archs4(gene_name, which="tissue")
+        if data.empty:
+            result["log"] += f"No RNA-seq data found for the gene {gene_name}.\n"
+            return result
+        result["log"] += f"RNA-seq expression data for {gene_name} fetched successfully. Formatting the top {K} tissues:\n"
+        for index, row in data.iterrows():
+            if index < K:
+                result["tissues"].append({"tissue": row["id"], "median_tpm": row["median"]})
+            else:
+                break
+    except Exception as e:
+        result["log"] += f"An error occurred: {e}"
+    return result

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,33 @@
+name: biomni_e1
+channels:
+  - conda-forge
+  - defaults
+  - bioconda
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+      - numpy==2.1
+      - pandas
+      - matplotlib
+      - scipy
+      - statsmodels
+      - scikit-learn
+      - gradio
+      - langchain
+      - langgraph==0.3.18
+      - langchain_openai
+      - langchain_anthropic
+      - langchain_community
+      - openai
+      - beautifulsoup4
+      - lxml
+      - tqdm
+      - seaborn
+      - networkx
+      - requests
+      - pyyaml
+      - jupyter
+      - notebook
+      - ipykernel
+      - pytest

--- a/setup_path.sh
+++ b/setup_path.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Added by biomni setup
+# Remove any old paths first to avoid duplicates
+PATH=$(echo $PATH | tr ':' '\n' | grep -v "biomni_tools/bin" | tr '\n' ':' | sed 's/:$//')
+export PATH="f/bin:$PATH"


### PR DESCRIPTION
Biomni MCP Tool: get_rna_seq_archs4

This tool provides a modular MCP-compatible API for querying RNA-seq expression data from ARCHS4 for a given gene.
It returns the top K tissues by median TPM, making it reusable for any MCP client or agent.

- Input: gene_name (str), K (int, number of tissues to return)
- Output: dict with gene name, K, list of tissues (name + median TPM), and a log of steps performed

Example output:
{
    "gene_name": "TP53",
    "K": 5,
    "tissues": [
        {"tissue": "Liver", "median_tpm": 12.3},
        ...
    ],
    "log": "..."
}

This implementation is designed for easy integration, testing, and extension in the Biomni ecosystem.