### PR TITLE
Add dotenv support for easier environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Biomni Environment Configuration
+# Copy this file to .env and fill in your actual API keys
+
+# Required: Anthropic API Key for Claude models
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Optional: OpenAI API Key (if using OpenAI models)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Optional: AWS Bedrock Configuration (if using AWS Bedrock models)
+AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
+AWS_REGION=us-east-1
+
+# Optional: Custom model serving configuration
+# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
+# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+
+# Optional: Biomni data path (defaults to ./data)
+# BIOMNI_DATA_PATH=/path/to/your/data
+
+# Optional: Timeout settings
+# BIOMNI_TIMEOUT_SECONDS=600

--- a/README.md
+++ b/README.md
@@ -53,7 +53,46 @@ For the latest update, install from the github source version, or do:
 pip install git+https://github.com/snap-stanford/Biomni.git@main
 ```
 
-Lastly, configure your API keys in bash profile `~/.bashrc`:
+Lastly, configure your API keys using one of the following methods:
+
+#### Option 1: Using .env file (Recommended)
+
+Create a `.env` file in your project directory:
+
+```bash
+# Copy the example file
+cp .env.example .env
+
+# Edit the .env file with your actual API keys
+```
+
+Your `.env` file should look like:
+
+```env
+# Required: Anthropic API Key for Claude models
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Optional: OpenAI API Key (if using OpenAI models)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Optional: AWS Bedrock Configuration (if using AWS Bedrock models)
+AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
+AWS_REGION=us-east-1
+
+# Optional: Custom model serving configuration
+# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
+# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+
+# Optional: Biomni data path (defaults to ./data)
+# BIOMNI_DATA_PATH=/path/to/your/data
+
+# Optional: Timeout settings (defaults to 600 seconds)
+# BIOMNI_TIMEOUT_SECONDS=600
+```
+
+#### Option 2: Using shell environment variables
+
+Alternatively, configure your API keys in bash profile `~/.bashrc`:
 
 ```bash
 export ANTHROPIC_API_KEY="YOUR_API_KEY"

--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -4,6 +4,7 @@ import os
 import re
 from typing import Literal, TypedDict
 
+from dotenv import load_dotenv
 import pandas as pd
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.prompts import ChatPromptTemplate
@@ -26,6 +27,11 @@ from biomni.utils import (
     run_with_timeout,
     textify_api_dict,
 )
+
+
+if os.path.exists(".env"):
+    load_dotenv(".env", override=False)
+    print("Loaded environment variables from .env")
 
 
 class AgentState(TypedDict):

--- a/biomni_env/environment.yml
+++ b/biomni_env/environment.yml
@@ -35,3 +35,4 @@ dependencies:
       - pytest
       - transformers
       - sentencepiece
+      - python-dotenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "Biomni Team", email = "kexinh@cs.stanford.edu"}
 ]
 requires-python = ">=3.11"
-dependencies = ["pydantic", "langchain"]
+dependencies = ["pydantic", "langchain", "python-dotenv"]
 
 [project.urls]
 Homepage = "https://github.com/snap-stanford/biomni"


### PR DESCRIPTION
## What changed
- Added `.env` file support with `python-dotenv` dependency
- Created `.env.example` template file  
- Implemented environment variable priority (explicit params > system env > .env > defaults)
- Updated README with both configuration methods (.env recommended, legacy method still documented)

## Why this matters
- Per-project environment configuration 
- Simpler API key management
- Follows modern Python project standards
- Existing environment variable setup continues to work

## Usage
```bash
cp .env.example .env
# Edit .env file with your API keys
```

```python
from biomni.agent import A1
agent = A1()  # Auto-loads from .env
```