### PR TITLE
Fix: Resolve variable name conflict in self_critic implementation (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Lastly, configure your API keys using one of the following methods:
 
 <details>
 <summary>Click to expand</summary>
-  
+
 #### Option 1: Using .env file (Recommended)
 
 Create a `.env` file in your project directory:

--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -1092,7 +1092,7 @@ Each library is listed with its description to help you understand its functiona
             else:
                 raise ValueError(f"Unexpected next_step: {next_step}")
 
-        def self_critic(state: AgentState) -> AgentState:
+        def execute_self_critic(state: AgentState) -> AgentState:
             if self.critic_count < test_time_scale_round:
                 # Generate feedback based on message history
                 messages = state["messages"]
@@ -1127,7 +1127,7 @@ Each library is listed with its description to help you understand its functiona
         workflow.add_node("execute", execute)
 
         if self_critic:
-            workflow.add_node("self_critic", self_critic)
+            workflow.add_node("self_critic", execute_self_critic)
             # Add conditional edges
             workflow.add_conditional_edges(
                 "generate",


### PR DESCRIPTION
## Description

This PR fixes the variable name conflict in `self_critic` implementation as described in #93.

### Changes
- Renamed internal function from `self_critic` to `execute_self_critic`
- Updated function reference in `workflow.add_node()`
- Eliminated variable name confusion between parameter and internal function

### Testing
- ✅ Self-critic functionality works correctly
- ✅ No more variable name conflicts
- ✅ Backward compatibility maintained

Closes #93