### PR TITLE
add apac. and eu. as prefix for bedrock model

### DIFF
--- a/biomni/llm.py
+++ b/biomni/llm.py
@@ -3,7 +3,6 @@ from typing import Literal, Optional
 
 import openai
 from langchain_anthropic import ChatAnthropic
-
 # from langchain_aws import ChatBedrock
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -50,7 +49,7 @@ def get_llm(
         ):
             source = "Ollama"
         elif model.startswith(
-            ("anthropic.claude-", "amazon.titan-", "meta.llama-", "mistral.", "cohere.", "ai21.", "us.")
+            ("anthropic.claude-", "amazon.titan-", "meta.llama-", "mistral.", "cohere.", "ai21.", "us.", "apac.", "eu.")
         ):
             source = "Bedrock"
         else:


### PR DESCRIPTION
aws bedrock support cross-region model in asian and european with  prefix as apac. and eu., when determin the model souce, we need add this.