### PR TITLE
fix: enable F401 unused import checks and clean up imports

### DIFF
--- a/biomni/agent/__init__.py
+++ b/biomni/agent/__init__.py
@@ -1,1 +1,1 @@
-from biomni.agent.a1 import A1
+from biomni.agent.a1 import A1  # noqa: F401

--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -4,7 +4,7 @@ import os
 import re
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Literal, Optional, TypedDict
+from typing import Any, Literal, TypedDict
 
 import pandas as pd
 from dotenv import load_dotenv

--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -21,7 +21,6 @@ from biomni.tool.support_tools import run_python_repl
 from biomni.tool.tool_registry import ToolRegistry
 from biomni.utils import (
     check_and_download_s3_files,
-    download_and_unzip,
     function_to_api_schema,
     pretty_print,
     read_module2api,
@@ -1737,7 +1736,6 @@ Each library is listed with its description to help you understand its functiona
             FastMCP server object that you can run manually
         """
         import importlib
-        import inspect
 
         from mcp.server.fastmcp import FastMCP
 

--- a/biomni/agent/react.py
+++ b/biomni/agent/react.py
@@ -6,7 +6,7 @@ import signal
 from collections.abc import Sequence
 from functools import wraps
 from multiprocessing import Process, Queue
-from typing import Annotated, Optional, TypedDict
+from typing import Annotated, TypedDict
 
 from langchain_core.messages import BaseMessage, SystemMessage, ToolMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder

--- a/biomni/config.py
+++ b/biomni/config.py
@@ -6,8 +6,7 @@ Maintains full backward compatibility with existing code.
 """
 
 import os
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import dataclass
 
 
 @dataclass

--- a/biomni/llm.py
+++ b/biomni/llm.py
@@ -1,7 +1,6 @@
 import os
 from typing import TYPE_CHECKING, Literal, Optional
 
-import openai
 from langchain_core.language_models.chat_models import BaseChatModel
 
 if TYPE_CHECKING:

--- a/biomni/task/hle.py
+++ b/biomni/task/hle.py
@@ -134,7 +134,6 @@ class humanity_last_exam(base_task):
         }
 
     def output_class(self):
-        from typing import Optional
 
         from pydantic import BaseModel, Field
 

--- a/biomni/task/hle.py
+++ b/biomni/task/hle.py
@@ -134,7 +134,6 @@ class humanity_last_exam(base_task):
         }
 
     def output_class(self):
-
         from pydantic import BaseModel, Field
 
         class MultipleChoiceOutput(BaseModel):

--- a/biomni/task/lab_bench.py
+++ b/biomni/task/lab_bench.py
@@ -102,7 +102,6 @@ We require this because we use automatic parsing.
         }
 
     def output_class(self):
-
         from pydantic import BaseModel, Field
 
         class MultipleChoiceOutput(BaseModel):

--- a/biomni/task/lab_bench.py
+++ b/biomni/task/lab_bench.py
@@ -102,7 +102,6 @@ We require this because we use automatic parsing.
         }
 
     def output_class(self):
-        from typing import Optional
 
         from pydantic import BaseModel, Field
 

--- a/biomni/tool/__init__.py
+++ b/biomni/tool/__init__.py
@@ -1,1 +1,1 @@
-from biomni.utils import get_tool_decorated_functions
+from biomni.utils import get_tool_decorated_functions  # noqa: F401

--- a/biomni/tool/example_mcp_tools/pubmed_mcp.py
+++ b/biomni/tool/example_mcp_tools/pubmed_mcp.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 from Bio import Entrez
 from mcp.server.fastmcp import FastMCP

--- a/biomni/tool/genomics.py
+++ b/biomni/tool/genomics.py
@@ -182,7 +182,6 @@ def annotate_celltype_with_panhumanpy(
     import json
     import shutil
     import subprocess
-    import sys
     import tempfile
 
     def conda_env_exists(env_name):

--- a/biomni/tool/pharmacology.py
+++ b/biomni/tool/pharmacology.py
@@ -2030,7 +2030,6 @@ def _process_ddinter_data_inline(data_lake_path, output_dir):
     """
     import os
     import pickle
-    from collections import defaultdict
     from pathlib import Path
 
     import pandas as pd
@@ -2108,7 +2107,6 @@ def _standardize_drug_name_processing(drug_name):
 
 def _build_drug_registry_inline(dataframes):
     """Build comprehensive drug registry from all interactions."""
-    import pandas as pd
 
     drug_registry = {}
 

--- a/biomni/tool/systems_biology.py
+++ b/biomni/tool/systems_biology.py
@@ -16,7 +16,6 @@ def query_chatnt(question, sequence, device=-1):
     str
         Answer to the question
     """
-    import torch
     from transformers import pipeline
 
     pipe = pipeline(model="InstaDeepAI/ChatNT", trust_remote_code=True, device=device)
@@ -56,7 +55,6 @@ def perform_flux_balance_analysis(model_file, constraints=None, objective_reacti
     str
         Research log summarizing the FBA process and results
     """
-    import os
 
     import cobra
     import pandas as pd
@@ -320,7 +318,6 @@ def simulate_metabolic_network_perturbation(
     str
         Research log summarizing the steps taken and results obtained
     """
-    import os
 
     import cobra
     import numpy as np
@@ -627,7 +624,6 @@ def compare_protein_structures(pdb_file1, pdb_file2, chain_id1="A", chain_id2="A
     str
         A research log summarizing the structural comparison analysis
     """
-    import os
     import warnings
 
     import numpy as np
@@ -810,7 +806,6 @@ def simulate_renin_angiotensin_system_dynamics(
     str
         Research log summarizing the simulation steps and results
     """
-    import os
 
     import numpy as np
     import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ ignore = [
     "D203",
     # We want docstrings to start immediately after the opening triple quote
     "D213",
-    # Imports unused
-    "F401",
     # camcelcase imported as lowercase
     "N813",
     # module import not at top level of file


### PR DESCRIPTION
## Enable F401 checks and clean up unused imports

### Changes
- Enable F401 unused import detection in `pyproject.toml`
- Auto-fix 16 unused imports with `ruff check --fix`
- Add `# noqa: F401` for intentional imports in `__init__.py` files to prevent breaking changes


### Impact
- All ruff checks pass
- Cleaner code with no unused imports
