### PR TITLE
Feature: Synapse integration with search and download

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -3970,7 +3970,7 @@ def query_synapse(
     query_term: str | list[str] | None = None,
     return_fields: list[str] | None = None,
     max_results: int = 20,
-    query_type: str = "file",
+    query_type: str = "dataset",
     verbose: bool = True,
 ):
     """Query Synapse REST API for biomedical datasets and files.
@@ -3984,14 +3984,15 @@ def query_synapse(
     prompt : str, optional
         Natural language query about biomedical data (e.g., "Find drug screening datasets")
     query_term : str or list of str, optional
-        Specific search terms for Synapse search
+        Specific search terms for Synapse search. When multiple terms are provided
+        as a list, they are combined with AND logic (more terms = more restrictive). Start with 1-2 most relevant search terms.
     return_fields : list of str, optional
         Fields to return in results. Default: ["name", "node_type", "description"]
     max_results : int, default 20
         Maximum number of results to return. Default 20 is optimal for most searches.
         Use up to 50 if extensive results are desired for comprehensive analysis.
-    query_type : str, default "file"
-        Type of entity to search for ("file", "project", "folder", etc.)
+    query_type : str, default "dataset"
+        Type of entity to search for ("dataset", "file", "folder")
     verbose : bool, default True
         Whether to return full API response or formatted results
 
@@ -4008,10 +4009,10 @@ def query_synapse(
 
     Examples
     --------
-    # Natural language query
+    # Natural language
     query_synapse(prompt="Find drug screening datasets")
 
-    # Direct search terms
+    # Direct search (AND logic - finds datasets with both "cancer" AND "genomics")
     query_synapse(query_term=["cancer", "genomics"], max_results=10)
 
     # Extensive search
@@ -4034,11 +4035,11 @@ def query_synapse(
     if prompt and not query_term:
         system_template = (
             "You extract search terms from natural language queries for biomedical data search.\n"
-            "Return ONLY a JSON object with this structure:\n"
-            '{"query_term": ["term1", "term2"], "query_type": "file", "max_results": 20}.\n'
-            "query_type should be 'file' for datasets/data files, 'project' for studies, or 'folder' for collections.\n"
+            "Return ONLY a JSON object with this structure, where query_term combines search terms using AND for each entry:\n"
+            '{"query_term": ["term1", "term2"], "query_type": "dataset", "max_results": 20}.\n'
+            "query_type should be 'dataset' for datasets, 'file' for data files, or 'folder' for collections.\n"
             "max_results should be 20 for typical searches, or up to 50 if extensive/comprehensive results are desired.\n"
-            "Extract 1-3 most relevant search terms. Do not include explanations."
+            "Start with 1-2 most relevant search terms (these are combined with AND; more terms = more restrictive). Do not include explanations."
         )
 
         llm_result = _query_llm_for_api(

--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -3963,3 +3963,127 @@ def query_emdb(
         api_result["result"] = _format_query_results(api_result["result"])
 
     return api_result
+
+
+def query_synapse(
+    prompt: str | None = None,
+    query_term: str | list[str] | None = None,
+    return_fields: list[str] | None = None,
+    max_results: int = 20,
+    query_type: str = "file",
+    verbose: bool = True,
+):
+    """Query Synapse REST API for biomedical datasets and files.
+
+    Synapse is a platform for sharing and analyzing biomedical data, particularly
+    genomics and clinical research datasets. Supports optional authentication via
+    SYNAPSE_AUTH_TOKEN environment variable for access to private datasets.
+
+    Parameters
+    ----------
+    prompt : str, optional
+        Natural language query about biomedical data (e.g., "Find drug screening datasets")
+    query_term : str or list of str, optional
+        Specific search terms for Synapse search
+    return_fields : list of str, optional
+        Fields to return in results. Default: ["name", "node_type", "description"]
+    max_results : int, default 20
+        Maximum number of results to return. Default 20 is optimal for most searches.
+        Use up to 50 if extensive results are desired for comprehensive analysis.
+    query_type : str, default "file"
+        Type of entity to search for ("file", "project", "folder", etc.)
+    verbose : bool, default True
+        Whether to return full API response or formatted results
+
+    Returns
+    -------
+    dict
+        Dictionary containing query information and Synapse API results
+
+    Notes
+    -----
+    Authentication is optional but recommended for access to private datasets.
+    Set SYNAPSE_AUTH_TOKEN environment variable with your Synapse personal access token
+    to enable authenticated requests.
+
+    Examples
+    --------
+    # Natural language query
+    query_synapse(prompt="Find drug screening datasets")
+
+    # Direct search terms
+    query_synapse(query_term=["cancer", "genomics"], max_results=10)
+
+    # Extensive search
+    query_synapse(query_term="alzheimer", max_results=50)
+
+    """
+    base_url = "https://repo-prod.prod.sagebase.org"
+
+    # Default return fields
+    if return_fields is None:
+        return_fields = ["name", "node_type", "description"]
+
+    # Check for optional authentication
+    headers = {"Content-Type": "application/json"}
+    synapse_token = os.environ.get("SYNAPSE_AUTH_TOKEN")
+    if synapse_token:
+        headers["Authorization"] = f"Bearer {synapse_token}"
+
+    # If natural language prompt provided, convert to search terms
+    if prompt and not query_term:
+        system_template = (
+            "You extract search terms from natural language queries for biomedical data search.\n"
+            "Return ONLY a JSON object with this structure:\n"
+            '{"query_term": ["term1", "term2"], "query_type": "file", "max_results": 20}.\n'
+            "query_type should be 'file' for datasets/data files, 'project' for studies, or 'folder' for collections.\n"
+            "max_results should be 20 for typical searches, or up to 50 if extensive/comprehensive results are desired.\n"
+            "Extract 1-3 most relevant search terms. Do not include explanations."
+        )
+
+        llm_result = _query_llm_for_api(
+            prompt=prompt,
+            schema=None,
+            system_template=system_template,
+        )
+
+        if llm_result.get("success"):
+            mapping = llm_result["data"] or {}
+            query_term = mapping.get("query_term", [])
+            query_type = mapping.get("query_type", query_type)
+            max_results = mapping.get("max_results", max_results)
+
+    # Build search request
+    search_url = f"{base_url}/repo/v1/search"
+
+    # Ensure query_term is a list
+    if isinstance(query_term, str):
+        query_term = [query_term]
+    elif query_term is None:
+        query_term = [""]
+
+    # Build search payload
+    search_payload = {
+        "queryTerm": query_term,
+        "returnFields": return_fields,
+        "start": 0,
+        "size": max_results,
+        "booleanQuery": [{"key": "node_type", "value": query_type}],
+    }
+
+    description = f"Synapse search for terms: {query_term} (query type: {query_type})"
+
+    # Execute search
+    api_result = _query_rest_api(
+        endpoint=search_url,
+        method="POST",
+        json_data=search_payload,
+        headers=headers,
+        description=description,
+    )
+
+    # Format results if not verbose and successful
+    if not verbose and api_result.get("success") and "result" in api_result:
+        api_result["result"] = _format_query_results(api_result["result"])
+
+    return api_result

--- a/biomni/tool/support_tools.py
+++ b/biomni/tool/support_tools.py
@@ -1,3 +1,4 @@
+
 import sys
 from io import StringIO
 
@@ -88,3 +89,134 @@ def read_function_source_code(function_name: str) -> str:
 #     human_response = input("Please provide your feedback: ")
 
 #     return human_response
+
+
+def download_synapse_data(
+    entity_ids: str | list[str],
+    download_location: str = ".",
+    follow_link: bool = False,
+    recursive: bool = False,
+    timeout: int = 300,
+):
+    """Download data from Synapse using entity IDs.
+
+    Uses the synapse CLI to download files, folders, or projects from Synapse.
+    Requires SYNAPSE_AUTH_TOKEN environment variable for authentication.
+    Automatically installs synapseclient if not available.
+
+    Parameters
+    ----------
+    entity_ids : str or list of str
+        Synapse entity ID(s) to download (e.g., "syn123456" or ["syn123", "syn456"])
+    download_location : str, default "."
+        Directory where files will be downloaded (current directory by default)
+    follow_link : bool, default False
+        Whether to follow links to download the linked entity
+    recursive : bool, default False
+        Whether to recursively download folders and their contents
+    timeout : int, default 300
+        Timeout in seconds for each download operation
+
+    Returns
+    -------
+    dict
+        Dictionary containing download results and any errors
+
+    Notes
+    -----
+    Requires SYNAPSE_AUTH_TOKEN environment variable with your Synapse personal
+    access token for authentication.
+
+    Examples
+    --------
+    # Download a single file to current directory
+    download_synapse_data("syn123456")
+
+    # Download multiple files to specific location
+    download_synapse_data(["syn123", "syn456"], download_location="/path/to/data")
+
+    # Download folder recursively with longer timeout
+    download_synapse_data("syn789", recursive=True, timeout=600)
+    """
+    import os
+    import subprocess
+
+    # Check for required authentication token
+    synapse_token = os.environ.get("SYNAPSE_AUTH_TOKEN")
+    if not synapse_token:
+        return {
+            "success": False,
+            "error": "SYNAPSE_AUTH_TOKEN environment variable is required for downloading",
+            "suggestion": "Set SYNAPSE_AUTH_TOKEN with your Synapse personal access token",
+        }
+
+    # Check if synapse CLI is available
+    try:
+        subprocess.run(["synapse", "--version"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        try:
+            # Try to install synapseclient
+            print("Installing synapseclient...")
+            subprocess.run(["pip", "install", "synapseclient"], check=True)
+            print("✓ synapseclient installed successfully")
+        except subprocess.CalledProcessError as e:
+            return {
+                "success": False,
+                "error": f"Failed to install synapseclient: {e}",
+                "suggestion": "Please install manually: pip install synapseclient",
+            }
+
+    # Ensure entity_ids is a list
+    if isinstance(entity_ids, str):
+        entity_ids = [entity_ids]
+
+    # Create download directory if it doesn't exist
+    os.makedirs(download_location, exist_ok=True)
+
+    results = []
+    errors = []
+
+    for entity_id in entity_ids:
+        try:
+            # Build synapse download command with authentication
+            cmd = ["synapse", "get", entity_id, "-p", synapse_token, "--downloadLocation", download_location]
+
+            if follow_link:
+                cmd.append("--followLink")
+            if recursive:
+                cmd.append("-r")
+
+            # Execute download
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=timeout)
+
+            results.append(
+                {
+                    "entity_id": entity_id,
+                    "success": True,
+                    "stdout": result.stdout,
+                    "download_location": download_location,
+                }
+            )
+
+        except subprocess.CalledProcessError as e:
+            error_msg = f"Failed to download {entity_id}: {e.stderr if e.stderr else str(e)}"
+            errors.append(error_msg)
+            results.append({"entity_id": entity_id, "success": False, "error": error_msg})
+        except subprocess.TimeoutExpired:
+            error_msg = f"Download timeout for {entity_id} (>{timeout} seconds)"
+            errors.append(error_msg)
+            results.append({"entity_id": entity_id, "success": False, "error": error_msg})
+
+    # Summary
+    successful_downloads = [r for r in results if r["success"]]
+    failed_downloads = [r for r in results if not r["success"]]
+
+    return {
+        "success": len(failed_downloads) == 0,
+        "total_requested": len(entity_ids),
+        "successful": len(successful_downloads),
+        "failed": len(failed_downloads),
+        "download_location": download_location,
+        "results": results,
+        "errors": errors if errors else None,
+    }

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -779,7 +779,7 @@ description = [
         ],
     },
     {
-        "description": "Query Synapse REST API for biomedical datasets and files using natural language or structured search parameters. Supports optional authentication via SYNAPSE_AUTH_TOKEN environment variable.",
+        "description": "Query Synapse REST API for biomedical datasets and files using natural language or structured search parameters. Supports optional authentication via SYNAPSE_AUTH_TOKEN environment variable. Results include 'access_restricted' property - if true, dataset requires approval via Synapse web interface and cannot be immediately accessed.",
         "name": "query_synapse",
         "optional_parameters": [
             {

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -778,4 +778,48 @@ description = [
             }
         ],
     },
+    {
+        "description": "Query Synapse REST API for biomedical datasets and files using natural language or structured search parameters. Supports optional authentication via SYNAPSE_AUTH_TOKEN environment variable.",
+        "name": "query_synapse",
+        "optional_parameters": [
+            {
+                "name": "query_term",
+                "type": "str|list[str]",
+                "description": "Specific search terms for Synapse search",
+                "default": None,
+            },
+            {
+                "name": "return_fields",
+                "type": "list[str]",
+                "description": "Fields to return in results",
+                "default": ["name", "node_type", "description"],
+            },
+            {
+                "name": "max_results",
+                "type": "int",
+                "description": "Maximum number of results to return. Default 20 is optimal for most searches. Use up to 50 if extensive results are desired for comprehensive analysis.",
+                "default": 20,
+            },
+            {
+                "name": "query_type",
+                "type": "str",
+                "description": "Type of entity to search for (file, project, folder, etc.)",
+                "default": "file",
+            },
+            {
+                "name": "verbose",
+                "type": "bool",
+                "description": "Whether to return full API response or formatted results",
+                "default": True,
+            },
+        ],
+        "required_parameters": [
+            {
+                "name": "prompt",
+                "type": "str",
+                "description": "Natural language query about biomedical data (e.g., 'Find drug screening datasets')",
+                "default": None,
+            }
+        ],
+    },
 ]

--- a/biomni/tool/tool_description/support_tools.py
+++ b/biomni/tool/tool_description/support_tools.py
@@ -28,7 +28,7 @@ description = [
         ],
     },
     {
-        "description": "Download data from Synapse using entity IDs. Requires SYNAPSE_AUTH_TOKEN environment variable for authentication. Automatically installs synapseclient if not available.",
+        "description": "Download data from Synapse using entity IDs. Requires SYNAPSE_AUTH_TOKEN environment variable for authentication. CRITICAL: Always specify entity_type parameter based on what you're downloading (file, dataset, folder, project). Check user hints like 'files' or search results to determine correct type. Multiple IDs only work with entity_type='file'. Recursive only works with entity_type='folder'.",
         "name": "download_synapse_data",
         "optional_parameters": [
             {
@@ -46,7 +46,7 @@ description = [
             {
                 "name": "recursive",
                 "type": "bool",
-                "description": "Whether to recursively download folders and their contents",
+                "description": "Whether to recursively download folders and their contents. ONLY valid with entity_type='folder'",
                 "default": False,
             },
             {
@@ -55,12 +55,18 @@ description = [
                 "description": "Timeout in seconds for each download operation",
                 "default": 300,
             },
+            {
+                "name": "entity_type",
+                "type": "str",
+                "description": "Type of Synapse entity: 'file', 'dataset', 'folder', or 'project'. MUST match actual entity type! Check user hints (e.g., 'files' means entity_type='file') or search results ('node_type' field). Default 'dataset' should only be used for actual datasets.",
+                "default": "dataset",
+            },
         ],
         "required_parameters": [
             {
                 "name": "entity_ids",
                 "type": "str|list[str]",
-                "description": "Synapse entity ID(s) to download (e.g., 'syn123456' or ['syn123', 'syn456'])",
+                "description": "Synapse entity ID(s) to download. For files: single ID or list of IDs. For datasets/folders/projects: single ID only",
                 "default": None,
             }
         ],

--- a/biomni/tool/tool_description/support_tools.py
+++ b/biomni/tool/tool_description/support_tools.py
@@ -27,4 +27,42 @@ description = [
             }
         ],
     },
+    {
+        "description": "Download data from Synapse using entity IDs. Requires SYNAPSE_AUTH_TOKEN environment variable for authentication. Automatically installs synapseclient if not available.",
+        "name": "download_synapse_data",
+        "optional_parameters": [
+            {
+                "name": "download_location",
+                "type": "str",
+                "description": "Directory where files will be downloaded",
+                "default": ".",
+            },
+            {
+                "name": "follow_link",
+                "type": "bool",
+                "description": "Whether to follow links to download the linked entity",
+                "default": False,
+            },
+            {
+                "name": "recursive",
+                "type": "bool",
+                "description": "Whether to recursively download folders and their contents",
+                "default": False,
+            },
+            {
+                "name": "timeout",
+                "type": "int",
+                "description": "Timeout in seconds for each download operation",
+                "default": 300,
+            },
+        ],
+        "required_parameters": [
+            {
+                "name": "entity_ids",
+                "type": "str|list[str]",
+                "description": "Synapse entity ID(s) to download (e.g., 'syn123456' or ['syn123', 'syn456'])",
+                "default": None,
+            }
+        ],
+    },
 ]


### PR DESCRIPTION
Close #150. I have [**notebook with the tests/demos here**](https://github.com/anngvu/Biomni/blob/feat/synapse-demo/tutorials/synapse_demo.ipynb). We still have to curate more potential analysis paths and validate the results, so the notebook may be updated with better examples. We're interested in running a Synapse workshop with open-source Biomni after this is merged 🤞🏼 . 

One thing I wasn't sure about is whether download functionality should be in `support_tools.py` (that seemed the closest fit module), or if you guys prefer a new file. Also, the decision was to dynamically add `synapseclient` for download only if someone is actually going to use it, instead of having it be in the starting/default environment. I think there might have been a GH issue suggesting more dynamic imports somewhere (to avoid bloat)... Anyway, please review and let me know if there is anything to be revised and make any edits you need.