### PR TITLE
Fix required parameter parsing for auto-discovered MCP tools

### DIFF
--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -467,11 +467,19 @@ class A1:
                     tool_name = tool_meta.get("biomni_name")
                     description = tool_meta.get("description", f"MCP tool: {tool_name}")
                     parameters = tool_meta.get("parameters", {})
+                    # For manual tools, check if each parameter has a "required" field
+                    required_param_names = []
+                    for param_name, param_spec in parameters.items():
+                        if param_spec.get("required", False):
+                            required_param_names.append(param_name)
                 else:
                     # Auto-discovered tool
                     tool_name = tool_meta.get("name")
                     description = tool_meta.get("description", f"MCP tool: {tool_name}")
-                    parameters = tool_meta.get("inputSchema", {}).get("properties", {})
+                    input_schema = tool_meta.get("inputSchema", {})
+                    parameters = input_schema.get("properties", {})
+                    # For auto-discovered tools, get required list from inputSchema top level
+                    required_param_names = input_schema.get("required", [])
 
                 if not tool_name:
                     print(f"Warning: Skipping tool with no name in {server_name}")
@@ -493,7 +501,8 @@ class A1:
                         "default": param_spec.get("default", None),
                     }
 
-                    if param_spec.get("required", False):
+                    # Check if parameter is required based on the required_param_names list
+                    if param_name in required_param_names:
                         required_params.append(param_info)
                     else:
                         optional_params.append(param_info)


### PR DESCRIPTION

## Problem
The current code incorrectly identifies required parameters for auto-discovered MCP tools by checking `param_spec.get("required", False)` on individual parameters, which always returns `False`.

## Root Cause
For auto-discovered MCP tools, the `required` field is located at the top level of `inputSchema`, not nested within each parameter property.

**Example MCP response structure:**
```json
{
  "inputSchema": {
    "properties": {
      "query": { "type": "string" },
      "max_results": { "type": "integer", "default": 10 }
    },
    "required": ["query"]  // ← required is here, not in properties
  }
}
```

## Solution
- **Manual tools**: Keep existing logic checking `required` field on each parameter
- **Auto-discovered tools**: Read `required` list from `inputSchema` top level
- **Parameter classification**: Use `required_param_names` list to correctly categorize required vs optional parameters

## Changes
- Modified `biomni/agent/a1.py` in `add_mcp` method
- Added proper handling for both manual and auto-discovered MCP tools
- Maintains backward compatibility

## Note
This PR only fixes the required parameter parsing issue for auto-discovered MCP tools. The manual tool definition branch (`biomni_name` check) is kept for backward compatibility as requested in #180.

Fixes #180 (partially - auto-discovered tools only)