### PR TITLE
Fix: a1 agent pass empty message to AWSbedrock error

### DIFF
--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -1283,7 +1283,7 @@ Each library is listed with its description to help you understand its functiona
                         new_content = content if content.strip() else "No content provided."
                     # Try to update the content. If the object is immutable, re-create the message.
                     try:
-                        setattr(msg, "content", new_content)
+                        msg.content = new_content
                     except Exception:
                         # Re-create new message object assuming its constructor accepts a content parameter.
                         messages[i] = type(msg)(content=new_content)
@@ -1291,7 +1291,7 @@ Each library is listed with its description to help you understand its functiona
                     # If the message is neither a dict nor has a 'content' attribute, skip it.
                     continue
             return messages
-            
+
         # Define the nodes
         def generate(state: AgentState) -> AgentState:
             messages = [SystemMessage(content=self.system_prompt)] + state["messages"]


### PR DESCRIPTION
### 1. Problem
Had intermittent error triggered by AWS Bedrock service as a local deployment. The error, showed as the [issue 172](https://github.com/snap-stanford/Biomni/issues/172), is a bug which will trigger error by bedrock server. When auto `Human Message` replies `Each response must include thinking process followed by either <execute> or <solution> tag. But there are no tags in the current response. Please follow the instruction, fix and regenerate the response again`, the Biomni agent actually sent the **_empty_** content to bedrock API which causes error.


### 2. Solution:
I added a new helper function named `sanitize_messages` to clean the message and ensure it doesn't send empty message to bedrock. Note, I **did NOT** test the script on other LLM models since I only have access to AWS bedrock. It solved the error when calling AWS bedrock. 


#### 2a) Call sanitize_message in generate function:
```
        def generate(state: AgentState) -> AgentState:
            messages = [SystemMessage(content=self.system_prompt)] + state["messages"]
            # Sanitize messages to ensure each 'content' is a nonempty string.
            messages = sanitize_messages(messages)
            response = self.llm.invoke(messages)
```


### 3. Need attention:
Although this sanitize function may fix the bug, I found there is a logic problem in the agent (`generate` function in `a1.py`). Sometime, the `Ai Message` will provide `<observation> xxx </observation>` instead of `<solution>`. The example in issue 172 that let the agent to list files in current directory and the agent replied with tag `<observation>`. However, the logic in `generate` function will only end the process when the response includes `<solution>`. Please consider adding `observation` in the ifelse loop to guide the agent for next step action.


### 4. Note:
Fixes [#172](https://github.com/snap-stanford/Biomni/issues/172) as requested.