### PR TITLE
Avoid blocking in google scholar research

### DIFF
--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -123,8 +123,7 @@ def query_scholar(query: str) -> str:
     - str: The first search result formatted or an error message.
 
     """
-    from scholarly import scholarly
-    from scholarly import ProxyGenerator
+    from scholarly import ProxyGenerator, scholarly
 
     # Set up a ProxyGenerator object to use free proxies
     # This needs to be done only once per session


### PR DESCRIPTION
Hi, accroding to the page of scholarly, using the publication search function might lead to the block of access to google scholar, and thus we might need to use free proxies

```
IMPORTANT: Making certain types of queries, such as scholarly.citedby or scholarly.search_pubs, will lead to Google Scholar blocking your requests and may eventually block your IP address. You must use proxy services to avoid this situation. See the ["Using proxies" section](https://scholarly.readthedocs.io/en/stable/quickstart.html#using-proxies) in the documentation for more details. Here's a short example:
```

https://github.com/scholarly-python-package/scholarly

I have implemented it and tested it.