### PR TITLE
Fix Gradio version compatibility issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,10 @@ agent.launch_gradio_demo()
 
 **Installation:**
 ```bash
-pip install gradio
+pip install "gradio>=5.0,<6.0"
 ```
+
+**Note:** Biomni's Gradio interface currently requires Gradio 5.x due to API changes in Gradio 6.0. If you have Gradio 6.x installed, you may need to downgrade.
 
 **Options:**
 - `share=True` - Create a public shareable link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = ["pydantic", "langchain", "python-dotenv"]
 Homepage = "https://github.com/snap-stanford/biomni"
 Repository = "https://github.com/snap-stanford/biomni"
 
+[project.optional-dependencies]
+gradio = ["gradio>=5.0,<6.0"]
+
 [tool.setuptools]
 include-package-data = true
 


### PR DESCRIPTION
The Gradio interface uses type="messages" parameter in Chatbot which was removed in Gradio 6.0. This causes a TypeError when users try to launch the Gradio demo with Gradio 6.x installed.

Changes:
- Add Gradio version constraint (>=5.0,<6.0) in pyproject.toml as optional dependency
- Update README.md to specify correct Gradio version in installation instructions
- Add note about Gradio 6.x incompatibility

This fixes the error:
TypeError: Chatbot.__init__() got an unexpected keyword argument 'type'

Users can now install with: pip install "biomni[gradio]"
Or manually: pip install "gradio>=5.0,<6.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)