### PR TITLE
Refactor genomics.py: lazy-load optional dependencies

### DIFF
--- a/biomni/tool/genomics.py
+++ b/biomni/tool/genomics.py
@@ -1,16 +1,12 @@
 import os
 from pathlib import Path
 
-import esm
 import gget
-import gseapy
 import numpy as np
 import pandas as pd
 import requests
 import scanpy as sc
 import torch
-from pybiomart import Dataset
-from tqdm import tqdm
 
 from biomni.llm import get_llm
 
@@ -152,6 +148,7 @@ def interspecies_gene_conversion(
     >>> print(result)
     Gene conversion results saved to: human_to_mouse_gene_conversion.csv
     """
+    from pybiomart import Dataset
 
     steps = []
 
@@ -336,6 +333,9 @@ def generate_gene_embeddings_with_ESM_models(
     Returns:
         String containing the steps performed during the embedding generation process
     """
+    import esm
+    from tqdm import tqdm
+
     steps = []
     steps.append(f"Loading ESM model: {model_name}")
     # model loading take a while, once loaded for smaller models generation is relatively fast
@@ -1015,6 +1015,8 @@ def get_rna_seq_archs4(gene_name: str, K: int = 10) -> str:
 
 
 def get_gene_set_enrichment_analysis_supported_database_list() -> list:
+    import gseapy
+
     return gseapy.get_library_name()
 
 


### PR DESCRIPTION
## Summary
This PR refactors `biomni/tool/genomics.py` to use lazy imports for optional/specialized dependencies, preventing import errors when these packages are not installed.

## Problem
Currently, `genomics.py` imports several optional dependencies at module-level:
- `esm` (fair-esm) - only used by 1 function
- `gseapy` - only used by 1 function
- `pybiomart.Dataset` - only used by 1 function
- `tqdm` - only used by 1 function

When any of these packages are missing, the entire module fails to load, blocking unrelated functionality. For example, ARCHS4 queries would fail with "No module named 'esm'" even though ARCHS4 doesn't use ESM.

## Solution
Move these imports from module-level to function-level (lazy imports), so they're only loaded when the specific functions that need them are called.

### Changes
- Move `import esm` into `generate_gene_embeddings_with_ESM_models()`
- Move `import gseapy` into `get_gene_set_enrichment_analysis_supported_database_list()`
- Move `from pybiomart import Dataset` into `interspecies_gene_conversion()`
- Move `from tqdm import tqdm` into `generate_gene_embeddings_with_ESM_models()`

## Benefits
1. **Better modularity** - Optional dependencies only loaded when needed
2. **Faster module loading** - Fewer upfront imports
3. **Improved resilience** - Missing optional packages don't block core functionality
4. **Fixes ARCHS4 issue** - `get_rna_seq_archs4()` now works without ESM installed

## Testing
- Core functions like `get_rna_seq_archs4()` now work without optional dependencies
- Functions using lazy-imported packages should work identically when those packages are installed
- No behavioral changes, only import timing changes

## Related
This change is particularly useful for minimal environment setups (e.g., using `environment.yml` instead of full `setup.sh` with all bioinformatics tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
