### PR TITLE
Fix UnicodeDecodeError when loading know-how docs on Windows

### DIFF
--- a/biomni/know_how/loader.py
+++ b/biomni/know_how/loader.py
@@ -39,7 +39,7 @@ class KnowHowLoader:
                 continue
 
             # Read the document
-            with open(filepath) as f:
+            with open(filepath, encoding="utf-8") as f:
                 content = f.read()
 
             # Extract title, description, and metadata from the document


### PR DESCRIPTION
On Windows, open() defaults to cp1252 encoding which fails to decode UTF-8 characters in the know-how markdown files. Explicitly specifying encoding="utf-8" fixes the crash for Windows users.