### PR TITLE
Add Dockerfile and entrypoint for containerized deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy and create conda environment from the reduced env file
-COPY biomni_env/fixed_env.yml /app/environment.yml
+# ENV_FILE selects the conda environment:
+#   biomni_env/fixed_env.yml  — reduced (~13GB, no R/CLI tools)
+#   biomni_env/bio_env.yml    — full (~30GB, includes R)
+ARG ENV_FILE=biomni_env/fixed_env.yml
+COPY ${ENV_FILE} /app/environment.yml
 RUN mamba env create -f /app/environment.yml -n biomni && \
     mamba clean -afy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,10 @@ COPY pyproject.toml README.md MANIFEST.in /app/
 COPY biomni/ /app/biomni/
 RUN pip install --no-cache-dir --no-deps ".[gradio,bedrock]"
 
+# Install langchain-aws separately with --no-deps to avoid numpy<2 conflict
+# (boto3 and langchain-core are already installed from the conda env)
+RUN pip install --no-cache-dir --no-deps "langchain-aws>=0.2,<0.3"
+
 # Copy entrypoint
 COPY docker/entrypoint.py /app/entrypoint.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM condaforge/mambaforge:latest AS base
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy and create conda environment from the reduced env file
+COPY biomni_env/fixed_env.yml /app/environment.yml
+RUN mamba env create -f /app/environment.yml -n biomni && \
+    mamba clean -afy
+
+# Activate the environment by default
+ENV PATH=/opt/conda/envs/biomni/bin:$PATH
+ENV CONDA_DEFAULT_ENV=biomni
+
+# Install biomni package
+COPY pyproject.toml README.md MANIFEST.in /app/
+COPY biomni/ /app/biomni/
+RUN pip install --no-cache-dir ".[gradio]"
+
+# Copy entrypoint
+COPY docker/entrypoint.py /app/entrypoint.py
+
+# Gradio UI port
+EXPOSE 7860
+# MCP server port
+EXPOSE 8000
+
+ENV BIOMNI_DATA_PATH=/app/data
+ENV GRADIO_SERVER_NAME=0.0.0.0
+
+CMD ["python", "/app/entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN find /opt/conda/envs/biomni -name '*.pyc' -delete && \
 # Install biomni package
 COPY pyproject.toml README.md MANIFEST.in /app/
 COPY biomni/ /app/biomni/
-RUN pip install --no-cache-dir --no-deps ".[gradio]"
+RUN pip install --no-cache-dir --no-deps ".[gradio,bedrock]"
 
 # Copy entrypoint
 COPY docker/entrypoint.py /app/entrypoint.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/mambaforge:latest AS base
+FROM condaforge/mambaforge:latest AS conda-base
 
 WORKDIR /app
 
@@ -14,17 +14,39 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #   biomni_env/bio_env.yml    — full (~30GB, includes R)
 ARG ENV_FILE=biomni_env/fixed_env.yml
 COPY ${ENV_FILE} /app/environment.yml
-RUN mamba env create -f /app/environment.yml -n biomni && \
-    mamba clean -afy
 
-# Activate the environment by default
+# Split: extract conda deps (no pip section) and install them first
+RUN sed '/^  - pip:/,$d' /app/environment.yml > /app/conda_only.yml && \
+    mamba env create -f /app/conda_only.yml -n biomni && \
+    mamba clean -afy && \
+    rm /app/conda_only.yml
+
+# Activate the environment
 ENV PATH=/opt/conda/envs/biomni/bin:$PATH
 ENV CONDA_DEFAULT_ENV=biomni
+
+# Install pip deps as a separate layer
+RUN sed -n '/^  - pip:/,$ { s/^      - //p }' /app/environment.yml > /app/pip_requirements.txt && \
+    if [ -s /app/pip_requirements.txt ]; then \
+        pip install --no-cache-dir -r /app/pip_requirements.txt; \
+    fi && \
+    rm /app/pip_requirements.txt
+
+# Remove caches and unnecessary files to slim down
+RUN find /opt/conda/envs/biomni -name '*.pyc' -delete && \
+    find /opt/conda/envs/biomni -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null; \
+    find /opt/conda/envs/biomni -name '*.a' -delete 2>/dev/null; \
+    rm -rf /opt/conda/envs/biomni/share/doc \
+           /opt/conda/envs/biomni/share/man \
+           /opt/conda/envs/biomni/share/info \
+           /opt/conda/envs/biomni/lib/python3.11/test \
+           /opt/conda/envs/biomni/lib/python3.11/unittest \
+    ; true
 
 # Install biomni package
 COPY pyproject.toml README.md MANIFEST.in /app/
 COPY biomni/ /app/biomni/
-RUN pip install --no-cache-dir ".[gradio]"
+RUN pip install --no-cache-dir --no-deps ".[gradio]"
 
 # Copy entrypoint
 COPY docker/entrypoint.py /app/entrypoint.py

--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -2034,13 +2034,16 @@ Each library is listed with its description to help you understand its functiona
                             print(f"Warning: Could not find function '{tool_name}' in module '{module_name}'")
                             continue
 
+                        # Truncate tool name to 64 chars (provider limit, e.g. AWS Bedrock)
+                        mcp_tool_name = tool_name[:64] if len(tool_name) > 64 else tool_name
+
                         # Extract parameters from your specific schema format
                         required_params = tool_schema.get("required_parameters", [])
                         optional_params = tool_schema.get("optional_parameters", [])
 
                         # Generate the wrapper function
                         wrapper_func = self._generate_mcp_wrapper_from_biomni_schema(
-                            fn, tool_name, required_params, optional_params
+                            fn, mcp_tool_name, required_params, optional_params
                         )
 
                         # Register with MCP

--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -2557,7 +2557,7 @@ Each library is listed with its description to help you understand its functiona
                     return {"error": str(e)}
 
             wrapper.__name__ = func_name
-            wrapper.__doc__ = original_func.__doc__
+            wrapper.__doc__ = original_func.__doc__ or f"Tool: {func_name}"
             return wrapper
 
         else:
@@ -2588,7 +2588,7 @@ Each library is listed with its description to help you understand its functiona
 
             # Set function metadata
             wrapper.__name__ = func_name
-            wrapper.__doc__ = original_func.__doc__
+            wrapper.__doc__ = original_func.__doc__ or f"Tool: {func_name}"
 
             # Create proper signature
             new_params = []

--- a/biomni_env/bio_env.yml
+++ b/biomni_env/bio_env.yml
@@ -4,6 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - python>=3.11
   - blast
   - samtools
   - bowtie2

--- a/biomni_env/bio_env.yml
+++ b/biomni_env/bio_env.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python>=3.11
+  - python=3.11
   - blast
   - samtools
   - bowtie2

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -34,7 +34,10 @@ def run_mcp(agent):
     tool_modules_str = os.environ.get("BIOMNI_MCP_TOOL_MODULES", "")
     tool_modules = [m.strip() for m in tool_modules_str.split(",") if m.strip()] or None
     mcp = agent.create_mcp_server(tool_modules=tool_modules)
-    mcp.run(transport="sse", host="0.0.0.0", port=8000)
+    mcp.settings.host = os.environ.get("BIOMNI_MCP_HOST", "0.0.0.0")
+    mcp.settings.port = int(os.environ.get("BIOMNI_MCP_PORT", "8000"))
+    transport = os.environ.get("BIOMNI_MCP_TRANSPORT", "sse")
+    mcp.run(transport=transport)
 
 
 if __name__ == "__main__":

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -1,0 +1,56 @@
+"""Entrypoint for Biomni Docker container.
+
+Supports two modes controlled by the BIOMNI_MODE environment variable:
+  - "gradio" (default): Launch the Gradio web UI on port 7860
+  - "mcp": Launch the MCP server (SSE transport) on port 8000
+  - "both": Launch both Gradio UI and MCP server
+"""
+
+import os
+import threading
+
+
+def run_gradio():
+    from biomni.agent.a1 import A1
+
+    data_path = os.environ.get("BIOMNI_DATA_PATH", "/app/data")
+    skip_data_lake = os.environ.get("BIOMNI_SKIP_DATA_LAKE", "false").lower() == "true"
+    require_verification = os.environ.get("BIOMNI_REQUIRE_VERIFICATION", "false").lower() == "true"
+
+    expected_files = [] if skip_data_lake else None
+    agent = A1(path=data_path, expected_data_lake_files=expected_files)
+    agent.launch_gradio_demo(
+        server_name="0.0.0.0",
+        share=False,
+        require_verification=require_verification,
+    )
+
+
+def run_mcp():
+    from biomni.agent.a1 import A1
+
+    data_path = os.environ.get("BIOMNI_DATA_PATH", "/app/data")
+    skip_data_lake = os.environ.get("BIOMNI_SKIP_DATA_LAKE", "false").lower() == "true"
+    tool_modules_str = os.environ.get("BIOMNI_MCP_TOOL_MODULES", "")
+
+    expected_files = [] if skip_data_lake else None
+    agent = A1(path=data_path, expected_data_lake_files=expected_files)
+
+    tool_modules = [m.strip() for m in tool_modules_str.split(",") if m.strip()] or None
+    mcp = agent.create_mcp_server(tool_modules=tool_modules)
+    mcp.run(transport="sse", host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    mode = os.environ.get("BIOMNI_MODE", "gradio").lower()
+
+    if mode == "gradio":
+        run_gradio()
+    elif mode == "mcp":
+        run_mcp()
+    elif mode == "both":
+        mcp_thread = threading.Thread(target=run_mcp, daemon=True)
+        mcp_thread.start()
+        run_gradio()
+    else:
+        raise ValueError(f"Unknown BIOMNI_MODE: {mode}. Use 'gradio', 'mcp', or 'both'.")

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -1,6 +1,6 @@
 """Entrypoint for Biomni Docker container.
 
-Supports two modes controlled by the BIOMNI_MODE environment variable:
+Supports three modes controlled by the BIOMNI_MODE environment variable:
   - "gradio" (default): Launch the Gradio web UI on port 7860
   - "mcp": Launch the MCP server (SSE transport) on port 8000
   - "both": Launch both Gradio UI and MCP server
@@ -10,15 +10,19 @@ import os
 import threading
 
 
-def run_gradio():
+def create_agent():
     from biomni.agent.a1 import A1
 
     data_path = os.environ.get("BIOMNI_DATA_PATH", "/app/data")
+    os.makedirs(data_path, exist_ok=True)
     skip_data_lake = os.environ.get("BIOMNI_SKIP_DATA_LAKE", "false").lower() == "true"
-    require_verification = os.environ.get("BIOMNI_REQUIRE_VERIFICATION", "false").lower() == "true"
 
     expected_files = [] if skip_data_lake else None
-    agent = A1(path=data_path, expected_data_lake_files=expected_files)
+    return A1(path=data_path, expected_data_lake_files=expected_files)
+
+
+def run_gradio(agent):
+    require_verification = os.environ.get("BIOMNI_REQUIRE_VERIFICATION", "false").lower() == "true"
     agent.launch_gradio_demo(
         server_name="0.0.0.0",
         share=False,
@@ -26,16 +30,8 @@ def run_gradio():
     )
 
 
-def run_mcp():
-    from biomni.agent.a1 import A1
-
-    data_path = os.environ.get("BIOMNI_DATA_PATH", "/app/data")
-    skip_data_lake = os.environ.get("BIOMNI_SKIP_DATA_LAKE", "false").lower() == "true"
+def run_mcp(agent):
     tool_modules_str = os.environ.get("BIOMNI_MCP_TOOL_MODULES", "")
-
-    expected_files = [] if skip_data_lake else None
-    agent = A1(path=data_path, expected_data_lake_files=expected_files)
-
     tool_modules = [m.strip() for m in tool_modules_str.split(",") if m.strip()] or None
     mcp = agent.create_mcp_server(tool_modules=tool_modules)
     mcp.run(transport="sse", host="0.0.0.0", port=8000)
@@ -43,14 +39,15 @@ def run_mcp():
 
 if __name__ == "__main__":
     mode = os.environ.get("BIOMNI_MODE", "gradio").lower()
+    agent = create_agent()
 
     if mode == "gradio":
-        run_gradio()
+        run_gradio(agent)
     elif mode == "mcp":
-        run_mcp()
+        run_mcp(agent)
     elif mode == "both":
-        mcp_thread = threading.Thread(target=run_mcp, daemon=True)
+        mcp_thread = threading.Thread(target=run_mcp, args=(agent,), daemon=True)
         mcp_thread.start()
-        run_gradio()
+        run_gradio(agent)
     else:
         raise ValueError(f"Unknown BIOMNI_MODE: {mode}. Use 'gradio', 'mcp', or 'both'.")

--- a/docs/known_conflicts.md
+++ b/docs/known_conflicts.md
@@ -10,8 +10,12 @@ This file lists Python packages that are known to have dependency conflicts with
 
 ### 2. langchain_aws
 - Needed for Amazon Bedrock support.
-- Amazon Bedrock support is present in the codebase, but due to package dependency conflicts, you should install `langchain_aws` only when you need Bedrock support.
-- You must also uncomment the relevant Bedrock support code sections in the codebase to enable this feature.
+- Amazon Bedrock support is fully implemented in the codebase. Install the package to enable it:
+  ```bash
+  pip install biomni[bedrock]
+  # or: pip install langchain-aws
+  ```
+- No code changes are needed — the package is imported at runtime when a Bedrock model is selected.
 
 ### 3. cnvkit
 - **Environment Requirement**: Requires Python 3.10 environment (`bio_env_py310.yml`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ Repository = "https://github.com/snap-stanford/biomni"
 
 [project.optional-dependencies]
 gradio = ["gradio>=5.0,<6.0"]
+bedrock = ["langchain-aws"]
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- Adds a `Dockerfile` using `condaforge/mambaforge` with the reduced conda environment (`fixed_env.yml`)
- Adds `docker/entrypoint.py` supporting three run modes via `BIOMNI_MODE` env var:
  - `gradio` (default): Gradio web UI on port 7860
  - `mcp`: MCP server with SSE transport on port 8000
  - `both`: runs both simultaneously
- Supports `ENV_FILE` build arg to select conda environment:
  - `biomni_env/fixed_env.yml` (default) — reduced env, fully pinned
  - `biomni_env/bio_env.yml` — full env including R
- Pins `python=3.11` in `bio_env.yml` (was resolving to 3.10/3.12, incompatible with biomni's `>=3.11` requirement)
- Optimizes Docker layers: splits conda/pip installs and cleans up caches, reducing image size from ~27GB to ~19GB

## Build

```bash
# Reduced env (default)
docker build -t cbioportal/biomni:latest .

# Full env with R
docker build --build-arg ENV_FILE=biomni_env/bio_env.yml -t cbioportal/biomni:full .
```

Images published: `cbioportal/biomni:latest` and `cbioportal/biomni:full`

## Test plan
- [x] Build Docker image (reduced env): `docker build -t biomni .`
- [x] Build Docker image (full env): `docker build --build-arg ENV_FILE=biomni_env/bio_env.yml -t biomni:full .`
- [x] Push to DockerHub
- [ ] Test Gradio mode: `docker run -e ANTHROPIC_API_KEY=... -p 7860:7860 cbioportal/biomni`
- [ ] Test MCP mode: `docker run -e ANTHROPIC_API_KEY=... -e BIOMNI_MODE=mcp -p 8000:8000 cbioportal/biomni`
- [ ] Test both mode: `docker run -e ANTHROPIC_API_KEY=... -e BIOMNI_MODE=both -p 7860:7860 -p 8000:8000 cbioportal/biomni`

🤖 Generated with [Claude Code](https://claude.com/claude-code)