### PR TITLE
setup.sh: pre-install numpy and cython before pystan

### DIFF
--- a/biomni_env/setup.sh
+++ b/biomni_env/setup.sh
@@ -168,6 +168,10 @@ main() {
 
     # Step 3: Install core bioinformatics tools (including QIIME2)
     echo -e "\n${YELLOW}Step 3: Installing core bioinformatics tools (including QIIME2)...${NC}"
+    # pystan (installed via pip in bio_env.yml) requires numpy and cython>=0.22 to be
+    # present at build time. Install them up front so its pyproject.toml metadata
+    # generation step does not fail on a fresh environment. See issue #283.
+    pip install "numpy" "cython>=0.22"
     install_env_file "bio_env.yml" "core bioinformatics tools"
 
     # Step 4: Install R packages


### PR DESCRIPTION
## Summary
Fixes `setup.sh` failure on fresh environments: `pystan` (installed via pip in `bio_env.yml`) requires `numpy` and `cython>=0.22` at build time, but they aren't present yet when Step 3 runs `conda env update -f bio_env.yml`. Pip aborts metadata generation for pystan with `Cython>=0.22 and NumPy are required.`, taking the whole setup down with it.

Installing `numpy` and `cython>=0.22` into the already-activated `biomni_e1` env immediately before Step 3 resolves it.

## Test plan
- [x] `bash -n biomni_env/setup.sh` syntax check passes
- [ ] Maintainer verification on a fresh environment

Fixes #283