### PR TITLE
feat: add Research Knowledge Graph module (Phase 1)

### DIFF
--- a/biomni/knowledge_graph/__init__.py
+++ b/biomni/knowledge_graph/__init__.py
@@ -1,0 +1,99 @@
+"""Research Knowledge Graph for Biomni.
+
+This module provides a knowledge graph for accumulating biomedical research knowledge
+across agent sessions. It captures entities (genes, proteins, drugs, diseases, etc.)
+and their relationships from tool outputs, persists them in SQLite, and surfaces
+relevant prior knowledge in future agent invocations.
+
+Main classes:
+    - KnowledgeGraph: Core graph management with persistence
+    - Entity: Biomedical entity (gene, protein, drug, disease, etc.)
+    - Relation: Directed relationship between two entities
+    - Storage: SQLite-based persistence backend
+
+Quick start:
+    >>> from biomni.knowledge_graph import KnowledgeGraph, Entity, Relation
+    >>> kg = KnowledgeGraph("my_research.db")
+    >>> tp53 = Entity(name="TP53", type="Gene", properties={"species": "human"})
+    >>> bax = Entity(name="BAX", type="Gene")
+    >>> kg.add_entity(tp53)
+    >>> kg.add_entity(bax)
+    >>> kg.add_relation(Relation(tp53, bax, type="REGULATES"))
+    >>> kg.get_stats()
+    {'entity_count': 2, 'relation_count': 1, 'entity_types': {'Gene': 2}, 'relation_types': {'REGULATES': 1}}
+"""
+
+from .entity import (
+    ANATOMY,
+    CELL_TYPE,
+    CHEMICAL,
+    DISEASE,
+    DRUG,
+    GENE,
+    GENE_ONTOLOGY,
+    ORGANISM,
+    PAPER,
+    PATHWAY,
+    PROTEIN,
+    VARIANT,
+    Entity,
+)
+from .graph import KnowledgeGraph
+from .relation import (
+    ACTIVATES,
+    ASSOCIATED_WITH,
+    BINDS,
+    CAUSES,
+    CONVERTS_TO,
+    ENCODES,
+    EXPRESSED_IN,
+    HAS_VARIANT,
+    INHIBITS,
+    INTERACTS_WITH,
+    MUTATED_IN,
+    PARTICIPATES_IN,
+    REGULATES,
+    RELATION_TYPES,
+    TARGETS,
+    TREATS,
+    Relation,
+)
+from .storage import Storage
+
+__all__ = [
+    # Core classes
+    "KnowledgeGraph",
+    "Entity",
+    "Relation",
+    "Storage",
+    # Entity type constants
+    "GENE",
+    "PROTEIN",
+    "DISEASE",
+    "DRUG",
+    "PATHWAY",
+    "VARIANT",
+    "CELL_TYPE",
+    "PAPER",
+    "CHEMICAL",
+    "ORGANISM",
+    "GENE_ONTOLOGY",
+    "ANATOMY",
+    # Relation type constants
+    "REGULATES",
+    "TARGETS",
+    "ASSOCIATED_WITH",
+    "ENCODES",
+    "BINDS",
+    "MUTATED_IN",
+    "CAUSES",
+    "TREATS",
+    "INHIBITS",
+    "ACTIVATES",
+    "PARTICIPATES_IN",
+    "INTERACTS_WITH",
+    "CONVERTS_TO",
+    "EXPRESSED_IN",
+    "HAS_VARIANT",
+    "RELATION_TYPES",
+]

--- a/biomni/knowledge_graph/entity.py
+++ b/biomni/knowledge_graph/entity.py
@@ -1,0 +1,113 @@
+"""Entity definitions for the Research Knowledge Graph.
+
+This module defines the Entity class and entity type constants used to represent
+biomedical entities (genes, proteins, drugs, diseases, etc.) in the knowledge graph.
+
+Entities are schema-less by design — any entity type can be added without predefined
+ontology constraints. Type alignment with BioPortal/OBO ontologies is deferred to
+Phase 4.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# Common biomedical entity types (not enforced — any string is valid)
+GENE = "Gene"
+PROTEIN = "Protein"
+DISEASE = "Disease"
+DRUG = "Drug"
+PATHWAY = "Pathway"
+VARIANT = "Variant"
+CELL_TYPE = "CellType"
+PAPER = "Paper"
+CHEMICAL = "Chemical"
+ORGANISM = "Organism"
+GENE_ONTOLOGY = "GeneOntology"
+ANATOMY = "Anatomy"
+
+
+@dataclass
+class Entity:
+    """A biomedical entity in the knowledge graph.
+
+    Attributes:
+        name: The canonical name of the entity (e.g., "TP53", "BRAF V600E").
+        type: The entity type (e.g., "Gene", "Drug", "Disease").
+        properties: Optional metadata dict (e.g., {"species": "human", "uniprot_id": "P04637"}).
+        source: Where this entity was first observed (e.g., "query_uniprot", "user_input").
+        id: Unique identifier. Auto-generated from name+type if not provided.
+
+    Examples:
+        >>> gene = Entity(name="TP53", type="Gene", properties={"species": "human"})
+        >>> drug = Entity(name="Vemurafenib", type="Drug", source="query_chembl")
+        >>> gene.id
+        'Gene:TP53'
+    """
+
+    name: str
+    type: str
+    properties: dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+    id: str = ""
+
+    def __post_init__(self):
+        """Generate ID from name and type if not provided."""
+        if not self.id:
+            self.id = self._generate_id()
+
+    def _generate_id(self) -> str:
+        """Generate a deterministic ID from name and type."""
+        return f"{self.type}:{self.name}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize entity to dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Entity:
+        """Deserialize entity from dictionary."""
+        return cls(**data)
+
+    def fingerprint(self) -> str:
+        """Generate a stable fingerprint for deduplication.
+
+        Two entities with the same name and type but different properties
+        are considered the same entity (properties are merged on conflict).
+        """
+        return hashlib.sha256(f"{self.type}:{self.name}".encode()).hexdigest()[:16]
+
+    def __hash__(self):
+        """Hash based on fingerprint for use in sets/dicts."""
+        return hash(self.fingerprint())
+
+    def __eq__(self, other):
+        """Equality based on fingerprint (name + type)."""
+        if not isinstance(other, Entity):
+            return False
+        return self.fingerprint() == other.fingerprint()
+
+    def merge_properties(self, other: Entity) -> Entity:
+        """Merge properties from another entity with the same name+type.
+
+        The other entity's properties take precedence for conflicting keys.
+        Returns a new Entity with merged properties.
+        """
+        merged_props = {**self.properties, **other.properties}
+        merged_source = self.source
+        if other.source and other.source not in self.source:
+            merged_source = f"{self.source},{other.source}" if self.source else other.source
+        return Entity(
+            name=self.name,
+            type=self.type,
+            properties=merged_props,
+            source=merged_source,
+            id=self.id,
+        )
+
+    def __repr__(self):
+        props_str = f", properties={self.properties}" if self.properties else ""
+        source_str = f", source='{self.source}'" if self.source else ""
+        return f"Entity(name='{self.name}', type='{self.type}'{props_str}{source_str})"

--- a/biomni/knowledge_graph/graph.py
+++ b/biomni/knowledge_graph/graph.py
@@ -1,0 +1,379 @@
+"""Core Knowledge Graph for biomedical research.
+
+This module provides the KnowledgeGraph class, which manages entities and relations
+for accumulating biomedical knowledge across agent sessions. It serves as the
+foundation for the Research Knowledge Graph feature in Biomni.
+
+The KnowledgeGraph provides:
+- Entity and relation management (add, query, merge)
+- Persistence via SQLite (zero external dependencies)
+- Query interface for retrieving relevant context
+- Statistics and introspection
+
+Examples:
+    >>> from biomni.knowledge_graph import KnowledgeGraph, Entity, Relation
+    >>> kg = KnowledgeGraph("my_research.db")
+    >>> tp53 = Entity(name="TP53", type="Gene", properties={"species": "human"})
+    >>> bax = Entity(name="BAX", type="Gene")
+    >>> kg.add_entity(tp53)
+    >>> kg.add_entity(bax)
+    >>> kg.add_relation(Relation(tp53, bax, type="REGULATES"))
+    >>> kg.query("TP53")
+    [Entity(name='TP53', type='Gene', properties={'species': 'human'})]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .storage import Storage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .entity import Entity
+    from .relation import Relation
+
+
+class KnowledgeGraph:
+    """A knowledge graph for accumulating biomedical research knowledge.
+
+    The KnowledgeGraph stores entities (genes, proteins, drugs, diseases, etc.)
+    and their relationships. It persists to SQLite for cross-session memory.
+
+    Attributes:
+        storage: The underlying SQLite storage backend.
+
+    Examples:
+        >>> kg = KnowledgeGraph()
+        >>> gene = Entity(name="BRAF", type="Gene")
+        >>> drug = Entity(name="Vemurafenib", type="Drug")
+        >>> kg.add_entity(gene)
+        >>> kg.add_entity(drug)
+        >>> kg.add_relation(Relation(drug, gene, type="TARGETS"))
+        >>> kg.get_stats()
+        {'entity_count': 2, 'relation_count': 1, ...}
+    """
+
+    def __init__(self, db_path: str | Path = "biomni_kg.db"):
+        """Initialize the knowledge graph.
+
+        Args:
+            db_path: Path to the SQLite database file. If the file doesn't exist,
+                     it will be created. Defaults to "biomni_kg.db" in the current
+                     directory.
+        """
+        self.storage = Storage(db_path)
+
+    # -------------------------------------------------------------------------
+    # Entity operations
+    # -------------------------------------------------------------------------
+
+    def add_entity(self, entity: Entity) -> Entity:
+        """Add an entity to the knowledge graph.
+
+        If an entity with the same name and type already exists, properties are
+        merged (existing properties take precedence for conflicts).
+
+        Args:
+            entity: The entity to add.
+
+        Returns:
+            The entity that was added (or merged with existing).
+        """
+        self.storage.save_entity(entity)
+        return entity
+
+    def get_entity(self, entity_id: str) -> Entity | None:
+        """Get an entity by its ID.
+
+        Args:
+            entity_id: The entity ID (e.g., "Gene:TP53").
+
+        Returns:
+            The entity if found, None otherwise.
+        """
+        return self.storage.load_entity(entity_id)
+
+    def query_entities(self, name: str | None = None, entity_type: str | None = None) -> list[Entity]:
+        """Query entities by name pattern and/or type.
+
+        Args:
+            name: Optional name pattern (case-insensitive partial match).
+            entity_type: Optional entity type filter (e.g., "Gene", "Drug").
+
+        Returns:
+            List of entities matching the query.
+        """
+        if name and entity_type:
+            # Filter by both name and type
+            entities = self.storage.query_entities_by_name(name)
+            return [e for e in entities if e.type == entity_type]
+        elif name:
+            return self.storage.query_entities_by_name(name)
+        elif entity_type:
+            return self.storage.query_entities_by_type(entity_type)
+        else:
+            return self.storage.load_all_entities()
+
+    def get_all_entities(self) -> list[Entity]:
+        """Get all entities in the knowledge graph.
+
+        Returns:
+            List of all entities.
+        """
+        return self.storage.load_all_entities()
+
+    # -------------------------------------------------------------------------
+    # Relation operations
+    # -------------------------------------------------------------------------
+
+    def add_relation(self, relation: Relation) -> Relation:
+        """Add a relation to the knowledge graph.
+
+        Source and target entities are automatically added if not already present.
+        If a relation with the same source, target, and type already exists,
+        properties are merged.
+
+        Args:
+            relation: The relation to add.
+
+        Returns:
+            The relation that was added (or merged with existing).
+        """
+        self.storage.save_relation(relation)
+        return relation
+
+    def get_relation(self, relation_id: str) -> Relation | None:
+        """Get a relation by its ID.
+
+        Args:
+            relation_id: The relation ID.
+
+        Returns:
+            The relation if found, None otherwise.
+        """
+        return self.storage.load_relation(relation_id)
+
+    def query_relations(
+        self,
+        source_entity_id: str | None = None,
+        target_entity_id: str | None = None,
+        relation_type: str | None = None,
+    ) -> list[Relation]:
+        """Query relations by source entity, target entity, and/or type.
+
+        Args:
+            source_entity_id: Optional source entity ID filter.
+            target_entity_id: Optional target entity ID filter.
+            relation_type: Optional relation type filter (e.g., "REGULATES").
+
+        Returns:
+            List of relations matching the query.
+        """
+        if source_entity_id and target_entity_id and relation_type:
+            # Filter by all three
+            relations = self.storage.query_relations_by_source(source_entity_id)
+            return [r for r in relations if r.target_entity.id == target_entity_id and r.type == relation_type]
+        elif source_entity_id and target_entity_id:
+            relations = self.storage.query_relations_by_source(source_entity_id)
+            return [r for r in relations if r.target_entity.id == target_entity_id]
+        elif source_entity_id and relation_type:
+            relations = self.storage.query_relations_by_source(source_entity_id)
+            return [r for r in relations if r.type == relation_type]
+        elif target_entity_id and relation_type:
+            relations = self.storage.query_relations_by_target(target_entity_id)
+            return [r for r in relations if r.type == relation_type]
+        elif source_entity_id:
+            return self.storage.query_relations_by_source(source_entity_id)
+        elif target_entity_id:
+            return self.storage.query_relations_by_target(target_entity_id)
+        elif relation_type:
+            return self.storage.query_relations_by_type(relation_type)
+        else:
+            return self.storage.load_all_relations()
+
+    def get_outgoing_relations(self, entity_id: str) -> list[Relation]:
+        """Get all relations originating from an entity.
+
+        Args:
+            entity_id: The source entity ID.
+
+        Returns:
+            List of outgoing relations.
+        """
+        return self.storage.query_relations_by_source(entity_id)
+
+    def get_incoming_relations(self, entity_id: str) -> list[Relation]:
+        """Get all relations pointing to an entity.
+
+        Args:
+            entity_id: The target entity ID.
+
+        Returns:
+            List of incoming relations.
+        """
+        return self.storage.query_relations_by_target(entity_id)
+
+    def get_all_relations(self) -> list[Relation]:
+        """Get all relations in the knowledge graph.
+
+        Returns:
+            List of all relations.
+        """
+        return self.storage.load_all_relations()
+
+    # -------------------------------------------------------------------------
+    # Graph traversal and context retrieval
+    # -------------------------------------------------------------------------
+
+    def get_neighbors(self, entity_id: str, depth: int = 1) -> dict[str, Any]:
+        """Get neighboring entities and relations up to a given depth.
+
+        This is useful for retrieving context around a specific entity.
+
+        Args:
+            entity_id: The starting entity ID.
+            depth: How many hops to traverse (default: 1).
+
+        Returns:
+            Dictionary with 'entities' and 'relations' lists.
+        """
+        visited_entities: set[str] = set()
+        visited_relations: set[str] = set()
+        entities: list[Entity] = []
+        relations: list[Relation] = []
+
+        # BFS traversal
+        queue = [(entity_id, 0)]
+
+        while queue:
+            current_id, current_depth = queue.pop(0)
+
+            if current_id in visited_entities:
+                continue
+            visited_entities.add(current_id)
+
+            # Get entity
+            entity = self.get_entity(current_id)
+            if entity:
+                entities.append(entity)
+
+            if current_depth >= depth:
+                continue
+
+            # Get outgoing relations
+            for rel in self.get_outgoing_relations(current_id):
+                if rel.id not in visited_relations:
+                    visited_relations.add(rel.id)
+                    relations.append(rel)
+                    queue.append((rel.target_entity.id, current_depth + 1))
+
+            # Get incoming relations
+            for rel in self.get_incoming_relations(current_id):
+                if rel.id not in visited_relations:
+                    visited_relations.add(rel.id)
+                    relations.append(rel)
+                    queue.append((rel.source_entity.id, current_depth + 1))
+
+        return {"entities": entities, "relations": relations}
+
+    def get_context_for_query(self, query: str, max_entities: int = 10, max_relations: int = 20) -> str:
+        """Generate context string for injection into agent system prompt.
+
+        This method extracts relevant entities and relations from the knowledge graph
+        that might be useful for answering the given query. Currently uses simple
+        name matching; future versions will use semantic similarity.
+
+        Args:
+            query: The user's query text.
+            max_entities: Maximum number of entities to include.
+            max_relations: Maximum number of relations to include.
+
+        Returns:
+            Formatted string with relevant knowledge graph context.
+        """
+        # Simple keyword-based matching (Phase 1)
+        # Future: semantic similarity with embeddings
+        query_lower = query.lower()
+        words = query_lower.split()
+
+        # Find entities whose names appear in the query
+        relevant_entities: list[Entity] = []
+        for word in words:
+            if len(word) < 3:  # Skip short words
+                continue
+            matches = self.query_entities(name=word)
+            relevant_entities.extend(matches)
+
+        # Deduplicate and limit
+        seen_ids: set[str] = set()
+        unique_entities: list[Entity] = []
+        for entity in relevant_entities:
+            if entity.id not in seen_ids and len(unique_entities) < max_entities:
+                seen_ids.add(entity.id)
+                unique_entities.append(entity)
+
+        # Get relations for these entities
+        relevant_relations: list[Relation] = []
+        for entity in unique_entities:
+            if len(relevant_relations) >= max_relations:
+                break
+            outgoing = self.get_outgoing_relations(entity.id)
+            incoming = self.get_incoming_relations(entity.id)
+            relevant_relations.extend(outgoing)
+            relevant_relations.extend(incoming)
+
+        # Deduplicate relations
+        seen_rel_ids: set[str] = set()
+        unique_relations: list[Relation] = []
+        for rel in relevant_relations:
+            if rel.id not in seen_rel_ids and len(unique_relations) < max_relations:
+                seen_rel_ids.add(rel.id)
+                unique_relations.append(rel)
+
+        # Format context string
+        if not unique_entities and not unique_relations:
+            return ""
+
+        context_parts = []
+
+        if unique_entities:
+            context_parts.append("Relevant entities from prior research:")
+            for entity in unique_entities:
+                props_str = ""
+                if entity.properties:
+                    props_items = [f"{k}={v}" for k, v in list(entity.properties.items())[:3]]
+                    props_str = f" ({', '.join(props_items)})"
+                context_parts.append(f"  - {entity.type}: {entity.name}{props_str}")
+
+        if unique_relations:
+            context_parts.append("\nRelevant relationships:")
+            for rel in unique_relations:
+                context_parts.append(f"  - {rel.source_entity.name} --[{rel.type}]--> {rel.target_entity.name}")
+
+        return "\n".join(context_parts)
+
+    # -------------------------------------------------------------------------
+    # Statistics and introspection
+    # -------------------------------------------------------------------------
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get statistics about the knowledge graph.
+
+        Returns:
+            Dictionary with entity count, relation count, and type breakdowns.
+        """
+        return self.storage.get_stats()
+
+    def __repr__(self):
+        stats = self.get_stats()
+        return f"KnowledgeGraph(entities={stats['entity_count']}, relations={stats['relation_count']})"
+
+    def close(self):
+        """Close the underlying storage connection."""
+        self.storage.close()
+
+    def __del__(self):
+        """Ensure storage is closed on garbage collection."""
+        self.close()

--- a/biomni/knowledge_graph/relation.py
+++ b/biomni/knowledge_graph/relation.py
@@ -1,0 +1,167 @@
+"""Relation definitions for the Research Knowledge Graph.
+
+This module defines the Relation class used to represent relationships between
+entities in the knowledge graph. Relations are directed edges connecting two entities.
+
+Relations are schema-less by design — any relation type can be added without predefined
+constraints. Common types include REGULATES, TARGETS, ASSOCIATED_WITH, etc.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from .entity import Entity
+
+# Common biomedical relation types (not enforced — any string is valid)
+REGULATES = "REGULATES"
+TARGETS = "TARGETS"
+ASSOCIATED_WITH = "ASSOCIATED_WITH"
+ENCODES = "ENCODES"
+BINDS = "BINDS"
+MUTATED_IN = "MUTATED_IN"
+CAUSES = "CAUSES"
+TREATS = "TREATS"
+INHIBITS = "INHIBITS"
+ACTIVATES = "ACTIVATES"
+PARTICIPATES_IN = "PARTICIPATES_IN"
+INTERACTS_WITH = "INTERACTS_WITH"
+CONVERTS_TO = "CONVERTS_TO"
+EXPRESSED_IN = "EXPRESSED_IN"
+HAS_VARIANT = "HAS_VARIANT"
+
+RELATION_TYPES = [
+    REGULATES,
+    TARGETS,
+    ASSOCIATED_WITH,
+    ENCODES,
+    BINDS,
+    MUTATED_IN,
+    CAUSES,
+    TREATS,
+    INHIBITS,
+    ACTIVATES,
+    PARTICIPATES_IN,
+    INTERACTS_WITH,
+    CONVERTS_TO,
+    EXPRESSED_IN,
+    HAS_VARIANT,
+]
+
+
+@dataclass
+class Relation:
+    """A directed relationship between two entities in the knowledge graph.
+
+    Attributes:
+        source_entity: The source entity of the relation.
+        target_entity: The target entity of the relation.
+        type: The relation type (e.g., "REGULATES", "TARGETS").
+        properties: Optional metadata (e.g., {"confidence": 0.95, "evidence": "STRING DB"}).
+        source: Where this relation was first observed (e.g., "query_stringdb", "user_input").
+        id: Unique identifier. Auto-generated if not provided.
+
+    Examples:
+        >>> tp53 = Entity(name="TP53", type="Gene")
+        >>> bax = Entity(name="BAX", type="Gene")
+        >>> rel = Relation(tp53, bax, type="REGULATES", properties={"evidence": "literature"})
+        >>> rel.id
+        'Gene:TP53--REGULATES-->Gene:BAX'
+    """
+
+    source_entity: Entity
+    target_entity: Entity
+    type: str
+    properties: dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+    id: str = ""
+
+    def __post_init__(self):
+        """Generate ID from entities and type if not provided."""
+        if not self.id:
+            self.id = self._generate_id()
+
+    def _generate_id(self) -> str:
+        """Generate a deterministic ID from source, target, and relation type."""
+        return f"{self.source_entity.id}--{self.type}-->{self.target_entity.id}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize relation to dictionary."""
+        return {
+            "id": self.id,
+            "source_entity": self.source_entity.to_dict(),
+            "target_entity": self.target_entity.to_dict(),
+            "type": self.type,
+            "properties": self.properties,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Relation:
+        """Deserialize relation from dictionary."""
+        return cls(
+            source_entity=Entity.from_dict(data["source_entity"]),
+            target_entity=Entity.from_dict(data["target_entity"]),
+            type=data["type"],
+            properties=data.get("properties", {}),
+            source=data.get("source", ""),
+            id=data.get("id", ""),
+        )
+
+    def fingerprint(self) -> str:
+        """Generate a stable fingerprint for deduplication.
+
+        Two relations with the same source, target, and type are considered
+        the same relation (properties are merged on conflict).
+        """
+        key = f"{self.source_entity.fingerprint()}:{self.type}:{self.target_entity.fingerprint()}"
+        return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+    def __hash__(self):
+        """Hash based on fingerprint for use in sets/dicts."""
+        return hash(self.fingerprint())
+
+    def __eq__(self, other):
+        """Equality based on fingerprint (source + type + target)."""
+        if not isinstance(other, Relation):
+            return False
+        return self.fingerprint() == other.fingerprint()
+
+    def merge_properties(self, other: Relation) -> Relation:
+        """Merge properties from another relation with the same source+target+type.
+
+        The other relation's properties take precedence for conflicting keys.
+        Returns a new Relation with merged properties.
+        """
+        merged_props = {**self.properties, **other.properties}
+        merged_source = self.source
+        if other.source and other.source not in self.source:
+            merged_source = f"{self.source},{other.source}" if self.source else other.source
+        return Relation(
+            source_entity=self.source_entity,
+            target_entity=self.target_entity,
+            type=self.type,
+            properties=merged_props,
+            source=merged_source,
+            id=self.id,
+        )
+
+    def reverse(self) -> Relation:
+        """Create a reversed relation (swap source and target entities)."""
+        return Relation(
+            source_entity=self.target_entity,
+            target_entity=self.source_entity,
+            type=self.type,
+            properties=self.properties.copy(),
+            source=self.source,
+        )
+
+    def __repr__(self):
+        props_str = f", properties={self.properties}" if self.properties else ""
+        source_str = f", source='{self.source}'" if self.source else ""
+        return (
+            f"Relation({self.source_entity.name!r} --[{self.type}]--> "
+            f"{self.target_entity.name!r}{props_str}{source_str})"
+        )

--- a/biomni/knowledge_graph/storage.py
+++ b/biomni/knowledge_graph/storage.py
@@ -1,0 +1,518 @@
+"""SQLite-based persistence for the Research Knowledge Graph.
+
+This module provides storage and retrieval of entities and relations using SQLite.
+SQLite was chosen for zero external dependencies and portability.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from .entity import Entity
+from .relation import Relation
+
+
+class Storage:
+    """SQLite-based storage for the knowledge graph.
+
+    Attributes:
+        db_path: Path to the SQLite database file.
+        conn: Active database connection.
+    """
+
+    def __init__(self, db_path: str | Path = "biomni_kg.db"):
+        """Initialize storage with the given database path.
+
+        Args:
+            db_path: Path to the SQLite database file. If the file doesn't exist,
+                     it will be created.
+        """
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(str(self.db_path))
+        self.conn.row_factory = sqlite3.Row
+        self._create_tables()
+
+    def _create_tables(self):
+        """Create the entities and relations tables if they don't exist."""
+        cursor = self.conn.cursor()
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS entities (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL,
+                properties TEXT NOT NULL DEFAULT '{}',
+                source TEXT NOT NULL DEFAULT '',
+                fingerprint TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_entities_fingerprint
+            ON entities(fingerprint)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_entities_type
+            ON entities(type)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_entities_name
+            ON entities(name)
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS relations (
+                id TEXT PRIMARY KEY,
+                source_entity_id TEXT NOT NULL,
+                target_entity_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                properties TEXT NOT NULL DEFAULT '{}',
+                source TEXT NOT NULL DEFAULT '',
+                fingerprint TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (source_entity_id) REFERENCES entities(id),
+                FOREIGN KEY (target_entity_id) REFERENCES entities(id)
+            )
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_relations_fingerprint
+            ON relations(fingerprint)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_relations_source_entity
+            ON relations(source_entity_id)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_relations_target_entity
+            ON relations(target_entity_id)
+        """)
+
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_relations_type
+            ON relations(type)
+        """)
+
+        self.conn.commit()
+
+    def save_entity(self, entity: Entity) -> None:
+        """Save or update an entity in the database.
+
+        If an entity with the same fingerprint exists, properties are merged.
+
+        Args:
+            entity: The entity to save.
+        """
+        cursor = self.conn.cursor()
+
+        # Check if entity with same fingerprint exists
+        cursor.execute(
+            "SELECT id, properties, source FROM entities WHERE fingerprint = ?",
+            (entity.fingerprint(),),
+        )
+        existing = cursor.fetchone()
+
+        if existing:
+            # Merge properties with existing entity
+            existing_props = json.loads(existing["properties"])
+            merged_props = {**existing_props, **entity.properties}
+            merged_source = existing["source"]
+            if entity.source and entity.source not in existing["source"]:
+                merged_source = f"{existing['source']},{entity.source}" if existing["source"] else entity.source
+
+            cursor.execute(
+                """
+                UPDATE entities
+                SET properties = ?, source = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE fingerprint = ?
+                """,
+                (json.dumps(merged_props), merged_source, entity.fingerprint()),
+            )
+        else:
+            # Insert new entity
+            cursor.execute(
+                """
+                INSERT INTO entities (id, name, type, properties, source, fingerprint)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entity.id,
+                    entity.name,
+                    entity.type,
+                    json.dumps(entity.properties),
+                    entity.source,
+                    entity.fingerprint(),
+                ),
+            )
+
+        self.conn.commit()
+
+    def save_relation(self, relation: Relation) -> None:
+        """Save or update a relation in the database.
+
+        If a relation with the same fingerprint exists, properties are merged.
+        Source and target entities are saved automatically if not already present.
+
+        Args:
+            relation: The relation to save.
+        """
+        # Ensure source and target entities exist
+        self.save_entity(relation.source_entity)
+        self.save_entity(relation.target_entity)
+
+        cursor = self.conn.cursor()
+
+        # Check if relation with same fingerprint exists
+        cursor.execute(
+            "SELECT id, properties, source FROM relations WHERE fingerprint = ?",
+            (relation.fingerprint(),),
+        )
+        existing = cursor.fetchone()
+
+        if existing:
+            # Merge properties with existing relation
+            existing_props = json.loads(existing["properties"])
+            merged_props = {**existing_props, **relation.properties}
+            merged_source = existing["source"]
+            if relation.source and relation.source not in existing["source"]:
+                merged_source = f"{existing['source']},{relation.source}" if existing["source"] else relation.source
+
+            cursor.execute(
+                """
+                UPDATE relations
+                SET properties = ?, source = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE fingerprint = ?
+                """,
+                (json.dumps(merged_props), merged_source, relation.fingerprint()),
+            )
+        else:
+            # Insert new relation
+            cursor.execute(
+                """
+                INSERT INTO relations
+                    (id, source_entity_id, target_entity_id, type, properties, source, fingerprint)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    relation.id,
+                    relation.source_entity.id,
+                    relation.target_entity.id,
+                    relation.type,
+                    json.dumps(relation.properties),
+                    relation.source,
+                    relation.fingerprint(),
+                ),
+            )
+
+        self.conn.commit()
+
+    def load_entity(self, entity_id: str) -> Entity | None:
+        """Load an entity by its ID.
+
+        Args:
+            entity_id: The entity ID (e.g., "Gene:TP53").
+
+        Returns:
+            The entity if found, None otherwise.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM entities WHERE id = ?", (entity_id,))
+        row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        return Entity(
+            id=row["id"],
+            name=row["name"],
+            type=row["type"],
+            properties=json.loads(row["properties"]),
+            source=row["source"],
+        )
+
+    def load_relation(self, relation_id: str) -> Relation | None:
+        """Load a relation by its ID.
+
+        Args:
+            relation_id: The relation ID.
+
+        Returns:
+            The relation if found, None otherwise.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM relations WHERE id = ?", (relation_id,))
+        row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        source_entity = self.load_entity(row["source_entity_id"])
+        target_entity = self.load_entity(row["target_entity_id"])
+
+        if not source_entity or not target_entity:
+            return None
+
+        return Relation(
+            id=row["id"],
+            source_entity=source_entity,
+            target_entity=target_entity,
+            type=row["type"],
+            properties=json.loads(row["properties"]),
+            source=row["source"],
+        )
+
+    def load_all_entities(self) -> list[Entity]:
+        """Load all entities from the database.
+
+        Returns:
+            List of all entities.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM entities")
+        rows = cursor.fetchall()
+
+        return [
+            Entity(
+                id=row["id"],
+                name=row["name"],
+                type=row["type"],
+                properties=json.loads(row["properties"]),
+                source=row["source"],
+            )
+            for row in rows
+        ]
+
+    def load_all_relations(self) -> list[Relation]:
+        """Load all relations from the database.
+
+        Returns:
+            List of all relations.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM relations")
+        rows = cursor.fetchall()
+
+        relations = []
+        for row in rows:
+            source_entity = self.load_entity(row["source_entity_id"])
+            target_entity = self.load_entity(row["target_entity_id"])
+
+            if source_entity and target_entity:
+                relations.append(
+                    Relation(
+                        id=row["id"],
+                        source_entity=source_entity,
+                        target_entity=target_entity,
+                        type=row["type"],
+                        properties=json.loads(row["properties"]),
+                        source=row["source"],
+                    )
+                )
+
+        return relations
+
+    def query_entities_by_type(self, entity_type: str) -> list[Entity]:
+        """Query entities by type.
+
+        Args:
+            entity_type: The entity type to filter by (e.g., "Gene", "Drug").
+
+        Returns:
+            List of entities matching the type.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT * FROM entities WHERE type = ?",
+            (entity_type,),
+        )
+        rows = cursor.fetchall()
+
+        return [
+            Entity(
+                id=row["id"],
+                name=row["name"],
+                type=row["type"],
+                properties=json.loads(row["properties"]),
+                source=row["source"],
+            )
+            for row in rows
+        ]
+
+    def query_entities_by_name(self, name: str) -> list[Entity]:
+        """Query entities by name (case-insensitive partial match).
+
+        Args:
+            name: The name pattern to search for.
+
+        Returns:
+            List of entities matching the name pattern.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT * FROM entities WHERE name LIKE ?",
+            (f"%{name}%",),
+        )
+        rows = cursor.fetchall()
+
+        return [
+            Entity(
+                id=row["id"],
+                name=row["name"],
+                type=row["type"],
+                properties=json.loads(row["properties"]),
+                source=row["source"],
+            )
+            for row in rows
+        ]
+
+    def query_relations_by_source(self, entity_id: str) -> list[Relation]:
+        """Query all relations where the given entity is the source.
+
+        Args:
+            entity_id: The source entity ID.
+
+        Returns:
+            List of relations originating from the entity.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT * FROM relations WHERE source_entity_id = ?",
+            (entity_id,),
+        )
+        rows = cursor.fetchall()
+
+        relations = []
+        for row in rows:
+            source_entity = self.load_entity(row["source_entity_id"])
+            target_entity = self.load_entity(row["target_entity_id"])
+
+            if source_entity and target_entity:
+                relations.append(
+                    Relation(
+                        id=row["id"],
+                        source_entity=source_entity,
+                        target_entity=target_entity,
+                        type=row["type"],
+                        properties=json.loads(row["properties"]),
+                        source=row["source"],
+                    )
+                )
+
+        return relations
+
+    def query_relations_by_target(self, entity_id: str) -> list[Relation]:
+        """Query all relations where the given entity is the target.
+
+        Args:
+            entity_id: The target entity ID.
+
+        Returns:
+            List of relations pointing to the entity.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT * FROM relations WHERE target_entity_id = ?",
+            (entity_id,),
+        )
+        rows = cursor.fetchall()
+
+        relations = []
+        for row in rows:
+            source_entity = self.load_entity(row["source_entity_id"])
+            target_entity = self.load_entity(row["target_entity_id"])
+
+            if source_entity and target_entity:
+                relations.append(
+                    Relation(
+                        id=row["id"],
+                        source_entity=source_entity,
+                        target_entity=target_entity,
+                        type=row["type"],
+                        properties=json.loads(row["properties"]),
+                        source=row["source"],
+                    )
+                )
+
+        return relations
+
+    def query_relations_by_type(self, relation_type: str) -> list[Relation]:
+        """Query all relations of a given type.
+
+        Args:
+            relation_type: The relation type to filter by (e.g., "REGULATES", "TARGETS").
+
+        Returns:
+            List of relations matching the type.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT * FROM relations WHERE type = ?",
+            (relation_type,),
+        )
+        rows = cursor.fetchall()
+
+        relations = []
+        for row in rows:
+            source_entity = self.load_entity(row["source_entity_id"])
+            target_entity = self.load_entity(row["target_entity_id"])
+
+            if source_entity and target_entity:
+                relations.append(
+                    Relation(
+                        id=row["id"],
+                        source_entity=source_entity,
+                        target_entity=target_entity,
+                        type=row["type"],
+                        properties=json.loads(row["properties"]),
+                        source=row["source"],
+                    )
+                )
+
+        return relations
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get statistics about the knowledge graph.
+
+        Returns:
+            Dictionary with entity count, relation count, and type breakdowns.
+        """
+        cursor = self.conn.cursor()
+
+        cursor.execute("SELECT COUNT(*) as count FROM entities")
+        entity_count = cursor.fetchone()["count"]
+
+        cursor.execute("SELECT COUNT(*) as count FROM relations")
+        relation_count = cursor.fetchone()["count"]
+
+        cursor.execute("SELECT type, COUNT(*) as count FROM entities GROUP BY type ORDER BY count DESC")
+        entity_types = {row["type"]: row["count"] for row in cursor.fetchall()}
+
+        cursor.execute("SELECT type, COUNT(*) as count FROM relations GROUP BY type ORDER BY count DESC")
+        relation_types = {row["type"]: row["count"] for row in cursor.fetchall()}
+
+        return {
+            "entity_count": entity_count,
+            "relation_count": relation_count,
+            "entity_types": entity_types,
+            "relation_types": relation_types,
+        }
+
+    def close(self):
+        """Close the database connection."""
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
+    def __del__(self):
+        """Ensure connection is closed on garbage collection."""
+        self.close()

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,314 @@
+"""Tests for the Research Knowledge Graph module."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from biomni.knowledge_graph import (
+    Entity,
+    KnowledgeGraph,
+    Relation,
+    Storage,
+)
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database file for testing."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+@pytest.fixture
+def kg(temp_db):
+    """Create a KnowledgeGraph with a temporary database."""
+    graph = KnowledgeGraph(temp_db)
+    yield graph
+    graph.close()
+
+
+class TestEntity:
+    def test_entity_creation(self):
+        entity = Entity(name="TP53", type="Gene")
+        assert entity.name == "TP53"
+        assert entity.type == "Gene"
+        assert entity.id == "Gene:TP53"
+        assert entity.properties == {}
+        assert entity.source == ""
+
+    def test_entity_with_properties(self):
+        entity = Entity(
+            name="TP53",
+            type="Gene",
+            properties={"species": "human", "uniprot_id": "P04637"},
+            source="query_uniprot",
+        )
+        assert entity.properties["species"] == "human"
+        assert entity.source == "query_uniprot"
+
+    def test_entity_equality(self):
+        e1 = Entity(name="TP53", type="Gene")
+        e2 = Entity(name="TP53", type="Gene", properties={"species": "human"})
+        assert e1 == e2  # Same name+type = equal
+
+    def test_entity_inequality(self):
+        e1 = Entity(name="TP53", type="Gene")
+        e2 = Entity(name="BAX", type="Gene")
+        assert e1 != e2
+
+    def test_entity_hash(self):
+        e1 = Entity(name="TP53", type="Gene")
+        e2 = Entity(name="TP53", type="Gene", properties={"species": "human"})
+        assert hash(e1) == hash(e2)
+
+    def test_entity_merge_properties(self):
+        e1 = Entity(name="TP53", type="Gene", properties={"species": "human"})
+        e2 = Entity(name="TP53", type="Gene", properties={"uniprot_id": "P04637"})
+        merged = e1.merge_properties(e2)
+        assert merged.properties["species"] == "human"
+        assert merged.properties["uniprot_id"] == "P04637"
+
+    def test_entity_to_dict(self):
+        entity = Entity(name="TP53", type="Gene", properties={"species": "human"})
+        d = entity.to_dict()
+        assert d["name"] == "TP53"
+        assert d["type"] == "Gene"
+        assert d["properties"]["species"] == "human"
+
+    def test_entity_from_dict(self):
+        d = {"name": "TP53", "type": "Gene", "properties": {"species": "human"}, "source": "", "id": "Gene:TP53"}
+        entity = Entity.from_dict(d)
+        assert entity.name == "TP53"
+        assert entity.type == "Gene"
+
+
+class TestRelation:
+    def test_relation_creation(self):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        rel = Relation(tp53, bax, type="REGULATES")
+        assert rel.source_entity == tp53
+        assert rel.target_entity == bax
+        assert rel.type == "REGULATES"
+        assert rel.id == "Gene:TP53--REGULATES-->Gene:BAX"
+
+    def test_relation_with_properties(self):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        rel = Relation(tp53, bax, type="REGULATES", properties={"confidence": 0.95})
+        assert rel.properties["confidence"] == 0.95
+
+    def test_relation_equality(self):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        r1 = Relation(tp53, bax, type="REGULATES")
+        r2 = Relation(tp53, bax, type="REGULATES", properties={"confidence": 0.95})
+        assert r1 == r2  # Same source+target+type = equal
+
+    def test_relation_inequality(self):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        r1 = Relation(tp53, bax, type="REGULATES")
+        r2 = Relation(bax, tp53, type="REGULATES")  # Reversed
+        assert r1 != r2
+
+    def test_relation_reverse(self):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        rel = Relation(tp53, bax, type="REGULATES")
+        reversed_rel = rel.reverse()
+        assert reversed_rel.source_entity == bax
+        assert reversed_rel.target_entity == tp53
+
+    def test_relation_to_dict(self):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        rel = Relation(tp53, bax, type="REGULATES")
+        d = rel.to_dict()
+        assert d["type"] == "REGULATES"
+        assert d["source_entity"]["name"] == "TP53"
+        assert d["target_entity"]["name"] == "BAX"
+
+    def test_relation_from_dict(self):
+        d = {
+            "id": "Gene:TP53--REGULATES-->Gene:BAX",
+            "source_entity": {"name": "TP53", "type": "Gene", "properties": {}, "source": "", "id": "Gene:TP53"},
+            "target_entity": {"name": "BAX", "type": "Gene", "properties": {}, "source": "", "id": "Gene:BAX"},
+            "type": "REGULATES",
+            "properties": {},
+            "source": "",
+        }
+        rel = Relation.from_dict(d)
+        assert rel.source_entity.name == "TP53"
+        assert rel.target_entity.name == "BAX"
+        assert rel.type == "REGULATES"
+
+
+class TestStorage:
+    def test_storage_creation(self, temp_db):
+        storage = Storage(temp_db)
+        assert storage.db_path == Path(temp_db)
+        storage.close()
+
+    def test_save_and_load_entity(self, temp_db):
+        storage = Storage(temp_db)
+        entity = Entity(name="TP53", type="Gene", properties={"species": "human"})
+        storage.save_entity(entity)
+
+        loaded = storage.load_entity("Gene:TP53")
+        assert loaded is not None
+        assert loaded.name == "TP53"
+        assert loaded.properties["species"] == "human"
+        storage.close()
+
+    def test_save_and_load_relation(self, temp_db):
+        storage = Storage(temp_db)
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        rel = Relation(tp53, bax, type="REGULATES")
+
+        storage.save_relation(rel)
+
+        loaded = storage.load_relation(rel.id)
+        assert loaded is not None
+        assert loaded.source_entity.name == "TP53"
+        assert loaded.target_entity.name == "BAX"
+        assert loaded.type == "REGULATES"
+        storage.close()
+
+    def test_query_entities_by_type(self, temp_db):
+        storage = Storage(temp_db)
+        storage.save_entity(Entity(name="TP53", type="Gene"))
+        storage.save_entity(Entity(name="BAX", type="Gene"))
+        storage.save_entity(Entity(name="Vemurafenib", type="Drug"))
+
+        genes = storage.query_entities_by_type("Gene")
+        assert len(genes) == 2
+        storage.close()
+
+    def test_query_entities_by_name(self, temp_db):
+        storage = Storage(temp_db)
+        storage.save_entity(Entity(name="TP53", type="Gene"))
+        storage.save_entity(Entity(name="TP53-Mutant", type="Variant"))
+
+        results = storage.query_entities_by_name("TP53")
+        assert len(results) == 2
+        storage.close()
+
+    def test_get_stats(self, temp_db):
+        storage = Storage(temp_db)
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        storage.save_entity(tp53)
+        storage.save_entity(bax)
+        storage.save_relation(Relation(tp53, bax, type="REGULATES"))
+
+        stats = storage.get_stats()
+        assert stats["entity_count"] == 2
+        assert stats["relation_count"] == 1
+        assert stats["entity_types"]["Gene"] == 2
+        assert stats["relation_types"]["REGULATES"] == 1
+        storage.close()
+
+
+class TestKnowledgeGraph:
+    def test_kg_creation(self, kg):
+        assert kg is not None
+        stats = kg.get_stats()
+        assert stats["entity_count"] == 0
+        assert stats["relation_count"] == 0
+
+    def test_add_entity(self, kg):
+        entity = Entity(name="TP53", type="Gene")
+        kg.add_entity(entity)
+        stats = kg.get_stats()
+        assert stats["entity_count"] == 1
+
+    def test_get_entity(self, kg):
+        kg.add_entity(Entity(name="TP53", type="Gene"))
+        entity = kg.get_entity("Gene:TP53")
+        assert entity is not None
+        assert entity.name == "TP53"
+
+    def test_query_entities(self, kg):
+        kg.add_entity(Entity(name="TP53", type="Gene"))
+        kg.add_entity(Entity(name="BAX", type="Gene"))
+        kg.add_entity(Entity(name="Vemurafenib", type="Drug"))
+
+        genes = kg.query_entities(entity_type="Gene")
+        assert len(genes) == 2
+
+        tp53 = kg.query_entities(name="TP53")
+        assert len(tp53) == 1
+        assert tp53[0].name == "TP53"
+
+    def test_add_relation(self, kg):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        rel = Relation(tp53, bax, type="REGULATES")
+        kg.add_relation(rel)
+
+        stats = kg.get_stats()
+        assert stats["entity_count"] == 2  # Auto-added
+        assert stats["relation_count"] == 1
+
+    def test_get_outgoing_relations(self, kg):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        kg.add_relation(Relation(tp53, bax, type="REGULATES"))
+
+        outgoing = kg.get_outgoing_relations("Gene:TP53")
+        assert len(outgoing) == 1
+        assert outgoing[0].target_entity.name == "BAX"
+
+    def test_get_incoming_relations(self, kg):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        kg.add_relation(Relation(tp53, bax, type="REGULATES"))
+
+        incoming = kg.get_incoming_relations("Gene:BAX")
+        assert len(incoming) == 1
+        assert incoming[0].source_entity.name == "TP53"
+
+    def test_get_neighbors(self, kg):
+        tp53 = Entity(name="TP53", type="Gene")
+        bax = Entity(name="BAX", type="Gene")
+        mdm2 = Entity(name="MDM2", type="Gene")
+        kg.add_relation(Relation(tp53, bax, type="REGULATES"))
+        kg.add_relation(Relation(mdm2, tp53, type="REGULATES"))
+
+        neighbors = kg.get_neighbors("Gene:TP53", depth=1)
+        assert len(neighbors["entities"]) == 3  # TP53, BAX, MDM2
+        assert len(neighbors["relations"]) == 2
+
+    def test_get_context_for_query(self, kg):
+        tp53 = Entity(name="TP53", type="Gene", properties={"species": "human"})
+        bax = Entity(name="BAX", type="Gene")
+        kg.add_relation(Relation(tp53, bax, type="REGULATES"))
+
+        context = kg.get_context_for_query("What does TP53 regulate?")
+        assert "TP53" in context
+        assert "BAX" in context
+        assert "REGULATES" in context
+
+    def test_persistence(self, temp_db):
+        kg1 = KnowledgeGraph(temp_db)
+        kg1.add_entity(Entity(name="TP53", type="Gene"))
+        kg1.close()
+
+        kg2 = KnowledgeGraph(temp_db)
+        entity = kg2.get_entity("Gene:TP53")
+        assert entity is not None
+        assert entity.name == "TP53"
+        kg2.close()
+
+    def test_repr(self, kg):
+        kg.add_entity(Entity(name="TP53", type="Gene"))
+        repr_str = repr(kg)
+        assert "KnowledgeGraph" in repr_str
+        assert "entities=1" in repr_str

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -5,7 +5,6 @@ import tempfile
 from pathlib import Path
 
 import pytest
-
 from biomni.knowledge_graph import (
     Entity,
     KnowledgeGraph,


### PR DESCRIPTION
## Summary

This PR introduces **Phase 1** of the Research Knowledge Graph feature ([#302](https://github.com/snap-stanford/Biomni/issues/302)) — a persistent entity-relation storage system that enables Biomni agents to accumulate biomedical knowledge across sessions.

## What's Included

### New Module: `biomni/knowledge_graph/`

| File | Purpose |
|------|---------|
| `entity.py` | Schema-less biomedical entity (Gene, Protein, Drug, Disease, Pathway, Variant, etc.) |
| `relation.py` | Directed relationship between two entities with type and properties |
| `graph.py` | Core KnowledgeGraph class with add/query/traverse/context API |
| `storage.py` | SQLite-based persistence backend (zero external dependencies) |
| `__init__.py` | Public API exports |

### Tests: `tests/test_knowledge_graph.py`

32 tests covering Entity, Relation, Storage, and KnowledgeGraph functionality.

## Key Features

- **Zero new dependencies** — uses only Python stdlib (sqlite3, dataclasses, hashlib)
- **Schema-less by design** — any entity type or relation type works without predefined constraints
- **Property merging** — duplicate entities/relations merge properties instead of failing
- **Graph traversal** — `get_neighbors(entity_id, depth=N)` for context retrieval
- **Context generation** — `get_context_for_query(query)` formats relevant KG context for system prompt injection
- **Cross-session persistence** — SQLite file survives agent restarts

## Usage Example

```python
from biomni.knowledge_graph import KnowledgeGraph, Entity, Relation

kg = KnowledgeGraph("my_research.db")

# Add entities and relations
tp53 = Entity(name="TP53", type="Gene", properties={"species": "human"})
bax = Entity(name="BAX", type="Gene")
kg.add_relation(Relation(tp53, bax, type="REGULATES", source="query_stringdb"))

# Query
results = kg.query_entities(name="TP53")
context = kg.get_context_for_query("What does TP53 regulate?")
print(context)
# Output:
# Relevant entities from prior research:
#   - Gene: TP53 (species=human)
#   - Gene: BAX
# Relevant relationships:
#   - TP53 --[REGULATES]--> BAX

# Cross-session: close and reopen
kg.close()
kg2 = KnowledgeGraph("my_research.db")
assert kg2.get_entity("Gene:TP53").name == "TP53"  # Persists!
```

## Design Decisions

1. **SQLite over Neo4j/DuckDB**: Zero dependencies, portable, no server required. Sufficient for Phase 1 scope.
2. **Schema-less entities**: No predefined ontology constraints. Phase 4 will add BioPortal/OBO alignment.
3. **Fingerprint-based dedup**: Entities with same name+type are merged (properties combined), not duplicated.
4. **Standalone module**: `biomni/knowledge_graph/` has no imports from other Biomni modules — can be reviewed and merged independently.

## Next Steps (Future PRs)

- **Phase 2**: LLM-based entity/relation extraction from tool outputs (`extractor.py`, `integration.py`)
- **Phase 3**: KG context injection into A1 agent system prompt (`retriever.py`)
- **Phase 4**: Visualization, confidence scoring, ontology alignment

## Testing

```bash
pytest tests/test_knowledge_graph.py -v
# 32 passed in 0.59s
```

All code passes `ruff check` and `ruff format --check`.

Closes #302 (Phase 1 of 4)
