### PR TITLE
Fix missing biomni.agent.base_agent module (#285)

### DIFF
--- a/biomni/agent/base_agent.py
+++ b/biomni/agent/base_agent.py
@@ -1,0 +1,17 @@
+from biomni.llm import get_llm
+
+
+class base_agent:
+    def __init__(self, llm="claude-3-haiku-20240307", cheap_llm=None, tools=None, temperature=0.7):
+        self.tools = tools
+        self.llm = get_llm(llm, temperature)
+        if cheap_llm is None:
+            self.cheap_llm = llm
+        else:
+            self.cheap_llm = cheap_llm
+
+    def configure(self):
+        pass
+
+    def go(self, input):
+        pass

--- a/biomni/agent/function_generator.py
+++ b/biomni/agent/function_generator.py
@@ -1,22 +1,6 @@
 import re
 
-from biomni.llm import get_llm
-
-
-class base_agent:
-    def __init__(self, llm="claude-3-haiku-20240307", cheap_llm=None, tools=None, temperature=0.7):
-        self.tools = tools
-        self.llm = get_llm(llm, temperature)
-        if cheap_llm is None:
-            self.cheap_llm = llm
-        else:
-            self.cheap_llm = cheap_llm
-
-    def configure(self):
-        pass
-
-    def go(self, input):
-        pass
+from biomni.agent.base_agent import base_agent
 
 
 class FunctionGenerator(base_agent):


### PR DESCRIPTION
## Summary

Fixes #285.

`biomni/agent/env_collection.py` imports the base class via:

```python
from biomni.agent.base_agent import base_agent
```

but no `base_agent.py` module existed — `base_agent` was defined inline inside `function_generator.py`. As a result, importing `PaperTaskExtractor` fails:

```
ModuleNotFoundError: No module named 'biomni.agent.base_agent'
```

## Fix

Extract `base_agent` into its own module `biomni/agent/base_agent.py` — the exact path `env_collection.py` already expects — and import it from there in `function_generator.py`. This resolves the broken import without changing `env_collection.py`, and both agent subclasses (`FunctionGenerator`, `PaperTaskExtractor`) now inherit from a single canonical base class.

Of the two options raised in the issue (repoint the import vs. refactor into its own file), this takes the refactor route since it matches the module path the code already references.

## Verification

- Before: `from biomni.agent.env_collection import PaperTaskExtractor` raised `ModuleNotFoundError`.
- After: `base_agent`, `FunctionGenerator`, and `PaperTaskExtractor` all import successfully, and both subclasses resolve to the same `base_agent` class object.
- `ruff check biomni/agent/` passes; pre-commit hooks pass.