### PR TITLE
feat: make marsilea visible to the agent

### DIFF
--- a/biomni/env_desc.py
+++ b/biomni/env_desc.py
@@ -122,6 +122,7 @@ library_content_dict = {
     "scikit-learn": "[Python Package] A machine learning library featuring various classification, regression, and clustering algorithms.",
     "matplotlib": "[Python Package] A comprehensive library for creating static, animated, and interactive visualizations in Python.",
     "seaborn": "[Python Package] A statistical data visualization library based on matplotlib with a high-level interface for drawing attractive statistical graphics.",
+    "marsilea": "[Python Package] Declarative creation of composable, multi-panel figures on top of matplotlib: annotated and clustered heatmaps, oncoprints, UpSet plots, sequence logos and alignments, and dot/bubble plots where size and color encode two different matrices (single-cell marker plots, GSEA enrichment). Start from a main plot and attach aligned side panels with add_top/add_bottom/add_left/add_right. Machine-readable API summary for agents: https://marsilea.readthedocs.io/llms.txt",
     "statsmodels": "[Python Package] A Python module for statistical modeling and econometrics, including descriptive statistics and estimation of statistical models.",
     "pymc3": "[Python Package] A Python package for Bayesian statistical modeling and probabilistic machine learning.",
     # "pystan": "[Python Package] A Python interface to Stan, a platform for statistical modeling and high-performance statistical computation.",

--- a/biomni/env_desc_cm.py
+++ b/biomni/env_desc_cm.py
@@ -122,6 +122,7 @@ library_content_dict = {
     "scikit-learn": "[Python Package] A machine learning library featuring various classification, regression, and clustering algorithms.",
     "matplotlib": "[Python Package] A comprehensive library for creating static, animated, and interactive visualizations in Python.",
     "seaborn": "[Python Package] A statistical data visualization library based on matplotlib with a high-level interface for drawing attractive statistical graphics.",
+    "marsilea": "[Python Package] Declarative creation of composable, multi-panel figures on top of matplotlib: annotated and clustered heatmaps, oncoprints, UpSet plots, sequence logos and alignments, and dot/bubble plots where size and color encode two different matrices (single-cell marker plots, GSEA enrichment). Start from a main plot and attach aligned side panels with add_top/add_bottom/add_left/add_right. Machine-readable API summary for agents: https://marsilea.readthedocs.io/llms.txt",
     "statsmodels": "[Python Package] A Python module for statistical modeling and econometrics, including descriptive statistics and estimation of statistical models.",
     "pymc3": "[Python Package] A Python package for Bayesian statistical modeling and probabilistic machine learning.",
     # "pystan": "[Python Package] A Python interface to Stan, a platform for statistical modeling and high-performance statistical computation.",

--- a/biomni_env/new_software_v008.sh
+++ b/biomni_env/new_software_v008.sh
@@ -16,3 +16,4 @@ pip install nnunet nibabel nilearn
 pip install mi-googlesearch-python
 pip install git+https://github.com/pylabrobot/pylabrobot.git
 conda install weasyprint
+pip install -U "marsilea>=0.7"


### PR DESCRIPTION
## Summary

**marsilea is already installed in the Biomni environment, but the agent has no
idea it exists.** `biomni_env/fixed_env.yml:470` pins `marsilea==0.5.4`, pulled in
transitively by `pip install lazyslide` in `new_software_v008.sh` — yet marsilea
is absent from `library_content_dict` in `env_desc.py`, while `matplotlib`,
`seaborn` and `lazyslide` are all listed.

Since `a1.py:1322` builds `library_content_list` from
`library_content_dict.keys()`, adding the entry puts marsilea and its description
straight into the system prompt.

[Marsilea](https://marsilea.readthedocs.io) is a declarative library for
composable, multi-panel figures on Matplotlib. It covers figures matplotlib and
seaborn cannot produce directly, several of them squarely biomedical:

- annotated and clustered heatmaps (the R ComplexHeatmap equivalent)
- oncoprints, UpSet plots, sequence logos and alignments
- dot/bubble plots where size and color encode two separate matrices —
  single-cell marker plots (expression × % of cells), GSEA enrichment (NES × FDR)

MIT licensed, published in *Genome Biology* 26, 5 (2025),
[10.1186/s13059-024-03469-3](https://doi.org/10.1186/s13059-024-03469-3), so it
belongs in both `env_desc.py` and `env_desc_cm.py`.

## Changes

Three files, **+3 / −0**:

| File | Change |
|---|---|
| `biomni/env_desc.py` | `"marsilea"` entry in `library_content_dict`, after `seaborn` |
| `biomni/env_desc_cm.py` | same entry (commercial-mode copy) |
| `biomni_env/new_software_v008.sh` | `pip install -U "marsilea>=0.7"` |

The description ends with the machine-readable
[`llms.txt`](https://marsilea.readthedocs.io/llms.txt) URL. Biomni has no
"read the docs of an installed package" tool, but `extract_url_content` is in
A1's default registry via `biomni/tool/literature.py`, so handing the agent the
URL lets it read the current API instead of guessing at it.

**On the version bump:** the transitive `0.5.4` pin is 8 releases behind current
(0.7.0) and predates the current API, so an agent reading present-day
documentation would emit code that fails against it. I appended the install line
to `new_software_v008.sh` since that is the only such script present — happy to
move it to a `v009` file if you would rather start one. I did not touch the
generated `fixed_env.yml`.

No new tool functions, no `biomni/utils.py` change, no new module.

## Test prompt

> Plot a clustered heatmap of these marker genes across cell types, with a
> cell-type annotation bar on the left and a bar chart of mean expression on top.

Before this change the agent reaches for matplotlib/seaborn and hand-assembles
the panels with GridSpec; after it, marsilea is listed in the prompt with its
description and the composable `add_top`/`add_left` model.

## Testing

- [x] Both `env_desc` modules import cleanly and contain the entry (114 / 112 entries)
- [x] `ruff check` — all checks passed; `ruff format --check` — already formatted
- [x] Traced the entry to the system prompt via `library_content_dict.keys()` at `a1.py:1322`
- [x] Verified the marsilea example code renders under marsilea 0.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)