### PR TITLE
Add gene symbol to Ensembl ID conversion tool

### DIFF
--- a/biomni/tool/genomics.py
+++ b/biomni/tool/genomics.py
@@ -105,6 +105,123 @@ def unsupervised_celltype_transfer_between_scRNA_datasets(
     return "\n".join(steps)
 
 
+def convert_gene_symbols_to_ensembl_ids(gene_symbols: list[str], species: str) -> dict[str, object]:
+    """Convert gene symbols to Ensembl gene identifiers with MyGene.info.
+
+    The input order and duplicate symbols are preserved. A symbol may map to more
+    than one Ensembl identifier (for example, a primary locus and an alternate
+    scaffold), so every identifier returned by MyGene.info is included.
+
+    Parameters
+    ----------
+    gene_symbols : list[str]
+        Gene symbols or short names to convert, such as ``["BRCA1", "TP53"]``.
+    species : str
+        A species name or NCBI taxonomy identifier accepted by MyGene.info, such
+        as ``"human"``, ``"mouse"``, ``"9606"``, or ``"10090"``.
+
+    Returns
+    -------
+    dict[str, object]
+        A summary and one result per input symbol. Each result contains the
+        original query, matched symbols, all Ensembl gene IDs, taxonomy IDs, and
+        a ``resolved`` flag.
+
+    Raises
+    ------
+    ValueError
+        If the input list or species is invalid.
+    RuntimeError
+        If MyGene.info returns an unexpected response shape.
+
+    """
+    if not isinstance(gene_symbols, list) or not gene_symbols:
+        raise ValueError("gene_symbols must be a non-empty list of strings")
+    if not isinstance(species, str) or not species.strip():
+        raise ValueError("species must be a non-empty string")
+
+    cleaned_symbols = []
+    for index, symbol in enumerate(gene_symbols):
+        if not isinstance(symbol, str) or not symbol.strip():
+            raise ValueError(f"gene_symbols[{index}] must be a non-empty string")
+        cleaned_symbol = symbol.strip()
+        if "," in cleaned_symbol:
+            raise ValueError(f"gene_symbols[{index}] must not contain a comma")
+        cleaned_symbols.append(cleaned_symbol)
+
+    species = species.strip()
+    unique_symbols = list(dict.fromkeys(cleaned_symbols))
+    matches_by_query: dict[str, dict[str, list[object]]] = {}
+
+    for start in range(0, len(unique_symbols), 1000):
+        batch = unique_symbols[start : start + 1000]
+        response = requests.post(
+            "https://mygene.info/v3/query",
+            data={
+                "q": ",".join(batch),
+                "scopes": "symbol",
+                "fields": "ensembl.gene,symbol,taxid",
+                "species": species,
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise RuntimeError("MyGene.info returned an unexpected response; expected a list")
+
+        for hit in payload:
+            if not isinstance(hit, dict) or not isinstance(hit.get("query"), str):
+                continue
+
+            query_matches = matches_by_query.setdefault(
+                hit["query"],
+                {"matched_symbols": [], "ensembl_ids": [], "taxids": []},
+            )
+
+            matched_symbol = hit.get("symbol")
+            if isinstance(matched_symbol, str) and matched_symbol not in query_matches["matched_symbols"]:
+                query_matches["matched_symbols"].append(matched_symbol)
+
+            taxid = hit.get("taxid")
+            if taxid is not None and taxid not in query_matches["taxids"]:
+                query_matches["taxids"].append(taxid)
+
+            ensembl = hit.get("ensembl")
+            ensembl_records = ensembl if isinstance(ensembl, list) else [ensembl]
+            for record in ensembl_records:
+                if isinstance(record, dict):
+                    identifiers = record.get("gene")
+                else:
+                    identifiers = record
+                identifiers = identifiers if isinstance(identifiers, list) else [identifiers]
+                for identifier in identifiers:
+                    if isinstance(identifier, str) and identifier not in query_matches["ensembl_ids"]:
+                        query_matches["ensembl_ids"].append(identifier)
+
+    results = []
+    for query in cleaned_symbols:
+        matches = matches_by_query.get(query, {"matched_symbols": [], "ensembl_ids": [], "taxids": []})
+        ensembl_ids = list(matches["ensembl_ids"])
+        results.append(
+            {
+                "query": query,
+                "matched_symbols": list(matches["matched_symbols"]),
+                "ensembl_ids": ensembl_ids,
+                "taxids": list(matches["taxids"]),
+                "resolved": bool(ensembl_ids),
+            }
+        )
+
+    resolved_count = sum(result["resolved"] for result in results)
+    return {
+        "species": species,
+        "resolved_count": resolved_count,
+        "unresolved_count": len(results) - resolved_count,
+        "results": results,
+    }
+
+
 def interspecies_gene_conversion(
     gene_list: list[str],
     source_species: str,

--- a/biomni/tool/tool_description/genomics.py
+++ b/biomni/tool/tool_description/genomics.py
@@ -636,6 +636,27 @@ description = [
         ],
     },
     {
+        "description": "Convert gene symbols or short names to Ensembl gene IDs using the MyGene.info batch "
+        "query service. The tool preserves input order and duplicate symbols, returns every Ensembl ID for "
+        "multi-locus matches, and explicitly marks unresolved symbols.",
+        "name": "convert_gene_symbols_to_ensembl_ids",
+        "optional_parameters": [],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "Gene symbols or short names to convert, for example ['BRCA1', 'TP53']",
+                "name": "gene_symbols",
+                "type": "list[str]",
+            },
+            {
+                "default": None,
+                "description": "Species name or NCBI taxonomy ID accepted by MyGene.info, such as human, mouse, 9606, or 10090",
+                "name": "species",
+                "type": "str",
+            },
+        ],
+    },
+    {
         "description": "Convert ENSEMBL gene IDs between different species using BioMart homology mapping. "
         "This function converts a list of ENSEMBL gene IDs from one species to their "
         "homologous counterparts in another species using the Ensembl BioMart database. "

--- a/tests/test_gene_symbol_conversion.py
+++ b/tests/test_gene_symbol_conversion.py
@@ -1,0 +1,182 @@
+import importlib.util
+import runpy
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[1]
+
+
+@pytest.fixture
+def genomics_module(monkeypatch):
+    """Load genomics.py without requiring Biomni's full scientific environment."""
+    for module_name in ("esm", "gget", "gseapy", "numpy", "pandas", "requests", "scanpy", "torch"):
+        monkeypatch.setitem(sys.modules, module_name, ModuleType(module_name))
+
+    pybiomart = ModuleType("pybiomart")
+    pybiomart.Dataset = object
+    monkeypatch.setitem(sys.modules, "pybiomart", pybiomart)
+
+    tqdm_module = ModuleType("tqdm")
+    tqdm_module.tqdm = lambda iterable=None, **_kwargs: iterable
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_module)
+
+    biomni_module = ModuleType("biomni")
+    biomni_module.__path__ = []
+    biomni_llm = ModuleType("biomni.llm")
+    biomni_llm.get_llm = lambda *_args, **_kwargs: None
+    monkeypatch.setitem(sys.modules, "biomni", biomni_module)
+    monkeypatch.setitem(sys.modules, "biomni.llm", biomni_llm)
+
+    spec = importlib.util.spec_from_file_location("genomics_under_test", REPO_ROOT / "biomni/tool/genomics.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_conversion_preserves_order_duplicates_all_ids_and_unresolved(genomics_module, monkeypatch):
+    payload = [
+        {
+            "query": "RNH1",
+            "symbol": "RNH1",
+            "taxid": 9606,
+            "ensembl": [{"gene": "ENSG00000023191"}, {"gene": "ENSG00000276230"}],
+        },
+        {"query": "BRCA1", "symbol": "BRCA1", "taxid": 9606, "ensembl": {"gene": "ENSG00000012048"}},
+        {"query": "NOT_A_GENE", "notfound": True},
+    ]
+    calls = []
+
+    def fake_post(url, data, timeout):
+        calls.append((url, data, timeout))
+        return FakeResponse(payload)
+
+    monkeypatch.setattr(genomics_module.requests, "post", fake_post, raising=False)
+
+    result = genomics_module.convert_gene_symbols_to_ensembl_ids([" BRCA1 ", "RNH1", "NOT_A_GENE", "BRCA1"], " human ")
+
+    assert result == {
+        "species": "human",
+        "resolved_count": 3,
+        "unresolved_count": 1,
+        "results": [
+            {
+                "query": "BRCA1",
+                "matched_symbols": ["BRCA1"],
+                "ensembl_ids": ["ENSG00000012048"],
+                "taxids": [9606],
+                "resolved": True,
+            },
+            {
+                "query": "RNH1",
+                "matched_symbols": ["RNH1"],
+                "ensembl_ids": ["ENSG00000023191", "ENSG00000276230"],
+                "taxids": [9606],
+                "resolved": True,
+            },
+            {
+                "query": "NOT_A_GENE",
+                "matched_symbols": [],
+                "ensembl_ids": [],
+                "taxids": [],
+                "resolved": False,
+            },
+            {
+                "query": "BRCA1",
+                "matched_symbols": ["BRCA1"],
+                "ensembl_ids": ["ENSG00000012048"],
+                "taxids": [9606],
+                "resolved": True,
+            },
+        ],
+    }
+    assert calls == [
+        (
+            "https://mygene.info/v3/query",
+            {
+                "q": "BRCA1,RNH1,NOT_A_GENE",
+                "scopes": "symbol",
+                "fields": "ensembl.gene,symbol,taxid",
+                "species": "human",
+            },
+            30,
+        )
+    ]
+
+
+def test_conversion_batches_more_than_1000_unique_symbols(genomics_module, monkeypatch):
+    batch_sizes = []
+
+    def fake_post(_url, data, timeout):
+        assert timeout == 30
+        symbols = data["q"].split(",")
+        batch_sizes.append(len(symbols))
+        return FakeResponse(
+            [
+                {
+                    "query": symbol,
+                    "symbol": symbol,
+                    "taxid": 9606,
+                    "ensembl": {"gene": f"ENSG{index:011d}"},
+                }
+                for index, symbol in enumerate(symbols)
+            ]
+        )
+
+    monkeypatch.setattr(genomics_module.requests, "post", fake_post, raising=False)
+    symbols = [f"GENE{index}" for index in range(1001)]
+
+    result = genomics_module.convert_gene_symbols_to_ensembl_ids(symbols, "9606")
+
+    assert batch_sizes == [1000, 1]
+    assert len(result["results"]) == 1001
+    assert result["resolved_count"] == 1001
+
+
+@pytest.mark.parametrize(
+    ("gene_symbols", "species", "error"),
+    [
+        ([], "human", "non-empty list"),
+        ("BRCA1", "human", "non-empty list"),
+        (["BRCA1", ""], "human", r"gene_symbols\[1\]"),
+        (["BRCA1", 53], "human", r"gene_symbols\[1\]"),
+        (["BRCA1,TP53"], "human", "must not contain a comma"),
+        (["BRCA1"], "", "species must be a non-empty string"),
+    ],
+)
+def test_conversion_validates_inputs(genomics_module, gene_symbols, species, error):
+    with pytest.raises(ValueError, match=error):
+        genomics_module.convert_gene_symbols_to_ensembl_ids(gene_symbols, species)
+
+
+def test_conversion_rejects_unexpected_api_response(genomics_module, monkeypatch):
+    monkeypatch.setattr(
+        genomics_module.requests,
+        "post",
+        lambda *_args, **_kwargs: FakeResponse({"hits": []}),
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="expected a list"):
+        genomics_module.convert_gene_symbols_to_ensembl_ids(["BRCA1"], "human")
+
+
+def test_tool_description_registers_function_and_required_parameters():
+    namespace = runpy.run_path(REPO_ROOT / "biomni/tool/tool_description/genomics.py")
+    schema = next(item for item in namespace["description"] if item["name"] == "convert_gene_symbols_to_ensembl_ids")
+
+    assert [parameter["name"] for parameter in schema["required_parameters"]] == ["gene_symbols", "species"]
+    assert schema["optional_parameters"] == []


### PR DESCRIPTION
## Summary

Add an agent-exposed `convert_gene_symbols_to_ensembl_ids` genomics tool backed by the MyGene.info batch query service.

This addresses #225 and follows the maintainer suggestion to use MyGene.info.

## Behavior

- accepts a list of gene symbols plus a MyGene-supported species name or taxonomy ID
- batches requests in groups of 1,000 and uses an explicit 30-second timeout plus HTTP status validation
- preserves input order, whitespace-normalized symbols, and duplicate inputs
- returns every Ensembl gene ID when MyGene reports multiple loci instead of silently discarding alternate matches
- explicitly marks unresolved symbols and reports resolved/unresolved totals
- adds the schema to the genomics tool registry without adding a dependency

## Testing

```text
uv run --python 3.11 --with pytest python -m pytest -q tests/test_gene_symbol_conversion.py
10 passed
```

The tests cover out-of-order API responses, duplicate inputs, multi-ID matches, unresolved symbols, 1,000-item batching, malformed responses, validation, and schema registration.

I also invoked the function against the live MyGene.info service:

- human `BRCA1` -> `ENSG00000012048`
- human `RNH1` -> `ENSG00000023191`, `ENSG00000276230`
- human `NOT_A_GENE` -> unresolved
- mouse `Brca1` and `Trp53` -> resolved with taxid `10090`

Finally, I constructed Biomni's actual LangChain `StructuredTool` from the registered schema and invoked it successfully. The wrapper exposed both expected arguments (`gene_symbols`, `species`) and returned one resolved and one unresolved result.

Repository pre-commit hooks pass for all changed files.

## Agent test prompt

```text
Using only the convert_gene_symbols_to_ensembl_ids tool, convert the human gene symbols BRCA1, RNH1, NOT_A_GENE, and BRCA1 to Ensembl gene IDs. Preserve the input order and duplicate BRCA1 entry, show every ID for multi-locus matches, and explicitly identify unresolved symbols.
```

## AI assistance

OpenAI Codex assisted with implementation and test development. I reviewed the changes and verified them with offline unit tests, live MyGene.info calls, the Biomni LangChain tool wrapper, and repository pre-commit hooks.

Closes #225
