### PR TITLE
Implement missing registration visualization tool

### DIFF
--- a/biomni/tool/bioimaging.py
+++ b/biomni/tool/bioimaging.py
@@ -955,6 +955,166 @@ class ImageRegistrationTool:
         logger.info("Similarity metrics calculated")
         return metrics
 
+    def create_registration_visualization(
+        self,
+        fixed_image: sitk.Image,
+        moving_image: sitk.Image,
+        registered_image: sitk.Image,
+        output_dir: str,
+        prefix: str = "registration",
+    ) -> dict[str, object]:
+        """Create comparison, difference, overlay, and metric plots for a registration.
+
+        Moving and registered images are resampled onto the fixed image's physical
+        grid with an identity transform before comparison. This makes the plots and
+        metrics well-defined even when the input images have different sizes,
+        origins, spacings, or directions.
+
+        Args:
+            fixed_image: Reference image defining the comparison grid.
+            moving_image: Original image before registration.
+            registered_image: Registered image in the fixed image's physical space.
+            output_dir: Directory in which to save PNG files.
+            prefix: Filename prefix for the generated plots.
+
+        Returns:
+            Dictionary containing four output paths and before/after metrics.
+
+        """
+        import matplotlib.pyplot as plt
+
+        images = {
+            "fixed_image": fixed_image,
+            "moving_image": moving_image,
+            "registered_image": registered_image,
+        }
+        dimensions = {name: image.GetDimension() for name, image in images.items()}
+        if dimensions["fixed_image"] not in (2, 3):
+            raise ValueError("Registration visualization supports only 2D or 3D images")
+        if len(set(dimensions.values())) != 1:
+            raise ValueError(f"All registration images must have the same dimension; got {dimensions}")
+        for name, image in images.items():
+            if image.GetNumberOfComponentsPerPixel() != 1:
+                raise ValueError(f"{name} must be a scalar image")
+
+        if not isinstance(prefix, str) or not prefix.strip():
+            raise ValueError("prefix must be a non-empty string")
+        if prefix in {".", ".."} or "/" in prefix or "\\" in prefix:
+            raise ValueError("prefix must be a filename prefix without path separators")
+
+        os.makedirs(output_dir, exist_ok=True)
+        fixed_on_reference = sitk.Cast(fixed_image, sitk.sitkFloat32)
+
+        def resample_to_fixed_grid(image: sitk.Image) -> sitk.Image:
+            resampler = sitk.ResampleImageFilter()
+            resampler.SetReferenceImage(fixed_on_reference)
+            resampler.SetTransform(sitk.Transform(fixed_on_reference.GetDimension(), sitk.sitkIdentity))
+            resampler.SetInterpolator(sitk.sitkLinear)
+            resampler.SetDefaultPixelValue(0.0)
+            resampler.SetOutputPixelType(sitk.sitkFloat32)
+            return resampler.Execute(image)
+
+        moving_on_reference = resample_to_fixed_grid(moving_image)
+        registered_on_reference = resample_to_fixed_grid(registered_image)
+
+        def central_slice(image: sitk.Image) -> np.ndarray:
+            image_array = sitk.GetArrayFromImage(image)
+            if image_array.ndim == 3:
+                return image_array[image_array.shape[0] // 2]
+            return image_array
+
+        def normalize_for_display(image_slice: np.ndarray) -> np.ndarray:
+            normalized = np.zeros(image_slice.shape, dtype=np.float32)
+            finite_mask = np.isfinite(image_slice)
+            if not finite_mask.any():
+                return normalized
+
+            finite_values = image_slice[finite_mask]
+            lower, upper = np.percentile(finite_values, [1.0, 99.0])
+            if upper <= lower:
+                lower, upper = finite_values.min(), finite_values.max()
+            if upper > lower:
+                normalized[finite_mask] = np.clip((finite_values - lower) / (upper - lower), 0.0, 1.0)
+            return normalized
+
+        fixed_slice = normalize_for_display(central_slice(fixed_on_reference))
+        moving_slice = normalize_for_display(central_slice(moving_on_reference))
+        registered_slice = normalize_for_display(central_slice(registered_on_reference))
+
+        comparison_path = os.path.join(output_dir, f"{prefix}_comparison.png")
+        figure, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
+        for axis, image_slice, title in zip(
+            axes,
+            (fixed_slice, moving_slice, registered_slice),
+            ("Fixed", "Moving (fixed grid)", "Registered"),
+            strict=True,
+        ):
+            axis.imshow(image_slice, cmap="gray", vmin=0.0, vmax=1.0)
+            axis.set_title(title)
+            axis.axis("off")
+        figure.savefig(comparison_path, dpi=150, bbox_inches="tight")
+        plt.close(figure)
+
+        difference_path = os.path.join(output_dir, f"{prefix}_difference.png")
+        figure, axis = plt.subplots(figsize=(5, 4), constrained_layout=True)
+        difference_plot = axis.imshow(np.abs(fixed_slice - registered_slice), cmap="inferno", vmin=0.0, vmax=1.0)
+        axis.set_title("Absolute difference: fixed vs. registered")
+        axis.axis("off")
+        figure.colorbar(difference_plot, ax=axis, fraction=0.046, pad=0.04)
+        figure.savefig(difference_path, dpi=150, bbox_inches="tight")
+        plt.close(figure)
+
+        overlay_path = os.path.join(output_dir, f"{prefix}_overlay.png")
+        overlay = np.zeros((*fixed_slice.shape, 3), dtype=np.float32)
+        overlay[..., 0] = registered_slice
+        overlay[..., 1] = fixed_slice
+        overlay[..., 2] = fixed_slice
+        figure, axis = plt.subplots(figsize=(5, 4), constrained_layout=True)
+        axis.imshow(overlay)
+        axis.set_title("Fixed (cyan) / registered (red)")
+        axis.axis("off")
+        figure.savefig(overlay_path, dpi=150, bbox_inches="tight")
+        plt.close(figure)
+
+        metrics_before = {
+            name: float(value)
+            for name, value in self.calculate_similarity_metrics(fixed_on_reference, moving_on_reference).items()
+        }
+        metrics_after = {
+            name: float(value)
+            for name, value in self.calculate_similarity_metrics(fixed_on_reference, registered_on_reference).items()
+        }
+        metrics_path = os.path.join(output_dir, f"{prefix}_metrics.png")
+        metric_labels = {
+            "mutual_information": "Mutual information",
+            "mean_squares": "Negative mean squared error",
+            "correlation": "Correlation",
+            "normalized_correlation": "Normalized correlation",
+        }
+        figure, axes = plt.subplots(2, 2, figsize=(10, 8))
+        figure.subplots_adjust(hspace=0.42, wspace=0.32, top=0.88, bottom=0.09)
+        for axis, (metric_name, label) in zip(axes.flat, metric_labels.items(), strict=True):
+            values = [metrics_before[metric_name], metrics_after[metric_name]]
+            bars = axis.bar(("Before", "After"), values, color=("#6c8ebf", "#82b366"))
+            axis.set_title(label)
+            axis.axhline(0.0, color="black", linewidth=0.8)
+            lower, upper = min(0.0, *values), max(0.0, *values)
+            span = max(upper - lower, max(abs(value) for value in values) * 0.1, 1e-9)
+            axis.set_ylim(lower - (0.15 * span if lower < 0 else 0.0), upper + 0.18 * span)
+            axis.bar_label(bars, fmt="%.4g", padding=3)
+        figure.suptitle("Registration similarity metrics", fontsize=15, y=0.97)
+        figure.savefig(metrics_path, dpi=150, bbox_inches="tight")
+        plt.close(figure)
+
+        return {
+            "comparison_path": comparison_path,
+            "difference_path": difference_path,
+            "overlay_path": overlay_path,
+            "metrics_path": metrics_path,
+            "metrics_before": metrics_before,
+            "metrics_after": metrics_after,
+        }
+
 
 # ============================================================================
 # CONVENIENCE FUNCTIONS FOR BIOMNI INTEGRATION
@@ -1104,6 +1264,15 @@ def quick_rigid_registration(
         "registration_type": "rigid",
     }
 
+    if create_visualizations:
+        results["visualizations"] = tool.create_registration_visualization(
+            fixed_image,
+            moving_image,
+            registered_image,
+            output_dir,
+            prefix="rigid",
+        )
+
     return results
 
 
@@ -1179,6 +1348,15 @@ def quick_affine_registration(
         "metrics_after": metrics_after,
         "registration_type": "affine",
     }
+
+    if create_visualizations:
+        results["visualizations"] = tool.create_registration_visualization(
+            fixed_image,
+            moving_image,
+            registered_image,
+            output_dir,
+            prefix="affine",
+        )
 
     return results
 
@@ -1257,6 +1435,15 @@ def quick_deformable_registration(
         "metrics_after": metrics_after,
         "registration_type": "deformable",
     }
+
+    if create_visualizations:
+        results["visualizations"] = tool.create_registration_visualization(
+            fixed_image,
+            moving_image,
+            registered_image,
+            output_dir,
+            prefix="deformable",
+        )
 
     return results
 
@@ -1392,3 +1579,36 @@ def calculate_similarity_metrics(image1_path: str, image2_path: str) -> dict[str
     image1 = tool.load_image(image1_path)
     image2 = tool.load_image(image2_path)
     return tool.calculate_similarity_metrics(image1, image2)
+
+
+def create_registration_visualization(
+    fixed_image_path: str,
+    moving_image_path: str,
+    registered_image_path: str,
+    output_dir: str,
+    prefix: str = "registration",
+) -> dict[str, object]:
+    """Create visualization plots for a completed medical image registration.
+
+    Args:
+        fixed_image_path: Path to the reference image.
+        moving_image_path: Path to the original moving image.
+        registered_image_path: Path to the registered image.
+        output_dir: Directory in which to save visualization files.
+        prefix: Prefix for generated PNG filenames.
+
+    Returns:
+        Dictionary containing visualization paths and before/after metrics.
+
+    """
+    tool = ImageRegistrationTool()
+    fixed_image = tool.load_image(fixed_image_path)
+    moving_image = tool.load_image(moving_image_path)
+    registered_image = tool.load_image(registered_image_path)
+    return tool.create_registration_visualization(
+        fixed_image,
+        moving_image,
+        registered_image,
+        output_dir,
+        prefix,
+    )

--- a/tests/test_registration_visualization.py
+++ b/tests/test_registration_visualization.py
@@ -1,0 +1,252 @@
+import importlib.util
+import json
+import runpy
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+import SimpleITK as sitk
+from PIL import Image
+
+REPO_ROOT = Path(__file__).parents[1]
+
+
+@pytest.fixture(scope="module")
+def bioimaging_module():
+    """Load bioimaging.py without Biomni's nnUNet and PyTorch environment."""
+    temporary_modules = {}
+
+    def install_stub(name, module):
+        temporary_modules[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    nibabel = ModuleType("nibabel")
+    requests = ModuleType("requests")
+    install_stub("nibabel", nibabel)
+    install_stub("requests", requests)
+
+    torch = ModuleType("torch")
+    torch_serialization = ModuleType("torch.serialization")
+    torch_serialization.add_safe_globals = lambda _items: None
+    torch.serialization = torch_serialization
+    install_stub("torch", torch)
+    install_stub("torch.serialization", torch_serialization)
+
+    nnunet = ModuleType("nnunet")
+    nnunet_inference = ModuleType("nnunet.inference")
+    nnunet_predict = ModuleType("nnunet.inference.predict")
+    nnunet_predict.predict_from_folder = lambda *_args, **_kwargs: None
+    install_stub("nnunet", nnunet)
+    install_stub("nnunet.inference", nnunet_inference)
+    install_stub("nnunet.inference.predict", nnunet_predict)
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "bioimaging_under_test",
+            REPO_ROOT / "biomni/tool/bioimaging.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name, previous in temporary_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+def make_scalar_image(shape):
+    coordinates = np.indices(shape, dtype=np.float32)
+    squared_radius = sum((axis - (size - 1) / 2.0) ** 2 for axis, size in zip(coordinates, shape, strict=True))
+    image = sitk.GetImageFromArray(np.exp(-squared_radius / 18.0).astype(np.float32))
+    image.SetSpacing(tuple(1.0 + 0.1 * index for index in range(image.GetDimension())))
+    return image
+
+
+def write_image(image, path):
+    sitk.WriteImage(image, str(path))
+    return str(path)
+
+
+def assert_png(path):
+    path = Path(path)
+    assert path.is_file()
+    assert path.stat().st_size > 0
+    with Image.open(path) as image:
+        assert image.format == "PNG"
+        assert image.width > 100
+        assert image.height > 100
+
+
+def test_standalone_visualization_creates_four_plots_and_metrics(bioimaging_module, tmp_path):
+    import matplotlib.pyplot as plt
+
+    fixed = make_scalar_image((7, 20, 18))
+    moving_array = np.roll(sitk.GetArrayFromImage(fixed), shift=2, axis=2)
+    moving = sitk.GetImageFromArray(moving_array)
+    moving.CopyInformation(fixed)
+    moving.SetOrigin((1.5, 0.0, 0.0))
+    registered = sitk.Image(fixed)
+
+    fixed_path = write_image(fixed, tmp_path / "fixed.mha")
+    moving_path = write_image(moving, tmp_path / "moving.mha")
+    registered_path = write_image(registered, tmp_path / "registered.mha")
+    output_dir = tmp_path / "plots"
+
+    result = bioimaging_module.create_registration_visualization(
+        fixed_path,
+        moving_path,
+        registered_path,
+        str(output_dir),
+        prefix="case01",
+    )
+
+    for key in ("comparison_path", "difference_path", "overlay_path", "metrics_path"):
+        assert_png(result[key])
+        assert Path(result[key]).parent == output_dir
+        assert Path(result[key]).name.startswith("case01_")
+
+    assert result["metrics_after"]["mean_squares"] == pytest.approx(0.0, abs=1e-10)
+    assert result["metrics_after"]["correlation"] == pytest.approx(1.0, abs=1e-7)
+    assert result["metrics_before"]["mean_squares"] < 0.0
+    json.dumps(result)
+    assert plt.get_fignums() == []
+
+
+def test_visualization_supports_2d_images(bioimaging_module, tmp_path):
+    fixed = make_scalar_image((24, 20))
+    moving = sitk.GetImageFromArray(np.roll(sitk.GetArrayFromImage(fixed), shift=1, axis=1))
+    moving.CopyInformation(fixed)
+    registered = sitk.Image(fixed)
+
+    result = bioimaging_module.ImageRegistrationTool().create_registration_visualization(
+        fixed,
+        moving,
+        registered,
+        str(tmp_path),
+        prefix="two_dimensional",
+    )
+
+    assert result["metrics_after"]["normalized_correlation"] == pytest.approx(1.0, abs=1e-7)
+    assert_png(result["overlay_path"])
+
+
+@pytest.mark.parametrize("prefix", ["", "  ", ".", "..", "../escape", "folder/name", r"folder\name"])
+def test_visualization_rejects_unsafe_prefixes(bioimaging_module, tmp_path, prefix):
+    image = make_scalar_image((12, 12))
+
+    with pytest.raises(ValueError, match="prefix"):
+        bioimaging_module.ImageRegistrationTool().create_registration_visualization(
+            image,
+            image,
+            image,
+            str(tmp_path),
+            prefix=prefix,
+        )
+
+
+def test_visualization_rejects_mixed_dimensions(bioimaging_module, tmp_path):
+    fixed = make_scalar_image((5, 12, 12))
+    moving = make_scalar_image((12, 12))
+
+    with pytest.raises(ValueError, match="same dimension"):
+        bioimaging_module.ImageRegistrationTool().create_registration_visualization(
+            fixed,
+            moving,
+            fixed,
+            str(tmp_path),
+        )
+
+
+def test_visualization_rejects_vector_images(bioimaging_module, tmp_path):
+    scalar = make_scalar_image((12, 12))
+    vector = sitk.Compose(scalar, scalar)
+
+    with pytest.raises(ValueError, match="moving_image must be a scalar image"):
+        bioimaging_module.ImageRegistrationTool().create_registration_visualization(
+            scalar,
+            vector,
+            scalar,
+            str(tmp_path),
+        )
+
+
+@pytest.mark.parametrize(
+    ("function_name", "prefix"),
+    [
+        ("quick_rigid_registration", "rigid"),
+        ("quick_affine_registration", "affine"),
+        ("quick_deformable_registration", "deformable"),
+    ],
+)
+def test_quick_registration_honors_visualization_flag(
+    bioimaging_module,
+    monkeypatch,
+    tmp_path,
+    function_name,
+    prefix,
+):
+    image = make_scalar_image((5, 12, 12))
+    visualization_calls = []
+    tool_class = bioimaging_module.ImageRegistrationTool
+
+    monkeypatch.setattr(tool_class, "load_image", lambda _self, _path: image)
+    monkeypatch.setattr(tool_class, "create_rigid_transform", lambda _self, *_args: "transform")
+    monkeypatch.setattr(tool_class, "create_affine_transform", lambda _self, *_args: "transform")
+    monkeypatch.setattr(tool_class, "create_deformable_transform", lambda _self, *_args: "transform")
+    monkeypatch.setattr(tool_class, "setup_registration_method", lambda _self, *_args: "method")
+    monkeypatch.setattr(tool_class, "register_images", lambda _self, *_args: ("final_transform", image))
+    monkeypatch.setattr(tool_class, "save_image", lambda _self, *_args: None)
+    monkeypatch.setattr(
+        tool_class,
+        "calculate_similarity_metrics",
+        lambda _self, *_args: {
+            "mutual_information": 1.0,
+            "mean_squares": 0.0,
+            "correlation": 1.0,
+            "normalized_correlation": 1.0,
+        },
+    )
+
+    def fake_visualization(_self, *_args, **kwargs):
+        visualization_calls.append(kwargs["prefix"])
+        return {"comparison_path": f"{kwargs['prefix']}_comparison.png"}
+
+    monkeypatch.setattr(tool_class, "create_registration_visualization", fake_visualization)
+    monkeypatch.setattr(bioimaging_module.sitk, "WriteTransform", lambda *_args: None)
+    registration_function = getattr(bioimaging_module, function_name)
+
+    result = registration_function(
+        "fixed.mha",
+        "moving.mha",
+        str(tmp_path / "enabled"),
+        preprocess=False,
+        create_visualizations=True,
+    )
+    result_without_plots = registration_function(
+        "fixed.mha",
+        "moving.mha",
+        str(tmp_path / "disabled"),
+        preprocess=False,
+        create_visualizations=False,
+    )
+
+    assert result["visualizations"] == {"comparison_path": f"{prefix}_comparison.png"}
+    assert "visualizations" not in result_without_plots
+    assert visualization_calls == [prefix]
+
+
+def test_registered_description_has_matching_implementation(bioimaging_module):
+    namespace = runpy.run_path(REPO_ROOT / "biomni/tool/tool_description/bioimaging.py")
+    schema = next(item for item in namespace["description"] if item["name"] == "create_registration_visualization")
+
+    assert callable(bioimaging_module.create_registration_visualization)
+    assert [parameter["name"] for parameter in schema["required_parameters"]] == [
+        "fixed_image_path",
+        "moving_image_path",
+        "registered_image_path",
+        "output_dir",
+    ]


### PR DESCRIPTION
## Summary

Implement the registered but missing `create_registration_visualization` bioimaging tool reported in #255.

The tool now produces:

- fixed / moving / registered comparison
- absolute fixed-vs-registered difference heatmap
- fixed (cyan) / registered (red) overlay
- before / after charts for mutual information, negative MSE, correlation, and normalized correlation

It returns all four PNG paths plus JSON-serializable before/after metrics.

## Registration correctness

The moving and registered images are resampled onto the fixed image's physical grid with an identity transform before array comparison. This uses the fixed image's size, origin, spacing, and direction rather than assuming that three input arrays already have the same shape or geometry. This follows the [SimpleITK `ResampleImageFilter` reference-image behavior](https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1ResampleImageFilter.html).

The implementation supports scalar 2D and 3D images and rejects mixed dimensions, vector pixels, and unsafe filename prefixes.

The existing `create_visualizations` switches in `quick_rigid_registration`, `quick_affine_registration`, and `quick_deformable_registration` are now honored; generated paths are returned under `result["visualizations"]`.

## Testing

```text
uv run --python 3.11 --with pytest --with numpy --with SimpleITK --with matplotlib --with pillow \
  python -m pytest -q tests/test_registration_visualization.py

15 passed
```

Tests use real SimpleITK 2D/3D images and validate physical-grid resampling, all four non-empty PNG outputs, exact post-registration metrics, JSON serialization, figure cleanup, prefix/dimension/vector validation, schema/implementation agreement, and visualization-switch behavior for all three quick registration paths.

I also ran a real five-iteration `quick_rigid_registration` smoke test on shifted 3D data. It wrote the registered NIfTI image, transform, and all four visualizations; negative MSE improved from `-0.0014597` to `-0.0011851`, and correlation improved from `0.97564` to `0.98014`.

Biomni's actual LangChain `StructuredTool` was constructed from the existing schema and invoked successfully. It exposed the four required path arguments, created all default `registration_*.png` files, and returned JSON-serializable metrics.

All repository pre-commit hooks pass for the changed files. The one test warning is from the pre-existing `np.core.multiarray.scalar` reference at the top of `bioimaging.py`.

## Agent test prompt

```text
Use only the create_registration_visualization tool to compare fixed.mha, moving.mha, and registered.mha. Save the outputs under ./registration_plots, then report every generated visualization path and summarize whether the similarity metrics improved after registration.
```

## AI assistance

OpenAI Codex assisted with implementation and test development. I reviewed the changes and verified them with unit tests, a real SimpleITK registration run, visual inspection of every generated plot, the Biomni LangChain tool wrapper, and repository pre-commit hooks.

Closes #255
