### PR TITLE
Fix custom provider environment variable mismatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,10 @@ AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
 AWS_REGION=us-east-1
 
 # Optional: Custom model serving configuration
-# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
-# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+# BIOMNI_SOURCE=Custom
+# BIOMNI_LLM=your_custom_model_name
+# BIOMNI_CUSTOM_BASE_URL=http://localhost:8000/v1
+# BIOMNI_CUSTOM_API_KEY=your_custom_api_key_here
 
 # Optional: Biomni data path (defaults to ./data)
 # BIOMNI_DATA_PATH=/path/to/your/data

--- a/README.md
+++ b/README.md
@@ -92,15 +92,16 @@ GROQ_API_KEY=your_groq_api_key_here
 
 # Optional: Set the source of your LLM for example:
 #"OpenAI", "AzureOpenAI", "Anthropic", "Ollama", "Gemini", "Bedrock", "Groq", "Custom"
-LLM_SOURCE=your_LLM_source_here
+BIOMNI_SOURCE=your_LLM_source_here
 
 # Optional: AWS Bedrock Configuration (if using AWS Bedrock models)
 AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
 AWS_REGION=us-east-1
 
 # Optional: Custom model serving configuration
-# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
-# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+# BIOMNI_LLM=your_custom_model_name
+# BIOMNI_CUSTOM_BASE_URL=http://localhost:8000/v1
+# BIOMNI_CUSTOM_API_KEY=your_custom_api_key_here
 
 # Optional: Biomni data path (defaults to ./data)
 # BIOMNI_DATA_PATH=/path/to/your/data
@@ -121,10 +122,19 @@ export AWS_BEARER_TOKEN_BEDROCK="YOUR_BEDROCK_API_KEY" # optional for AWS Bedroc
 export AWS_REGION="us-east-1" # optional, defaults to us-east-1 for Bedrock
 export GEMINI_API_KEY="YOUR_GEMINI_API_KEY" #optional if you want to use a gemini model
 export GROQ_API_KEY="YOUR_GROQ_API_KEY" # Optional: set this to use models served by Groq
-export LLM_SOURCE="Groq" # Optional: set this to use models served by Groq
+export BIOMNI_SOURCE="Groq" # Optional: set this to use models served by Groq
 
+# Optional: use an OpenAI-compatible custom provider
+# export BIOMNI_SOURCE="Custom"
+# export BIOMNI_LLM="your_custom_model_name"
+# export BIOMNI_CUSTOM_BASE_URL="http://localhost:8000/v1"
+# export BIOMNI_CUSTOM_API_KEY="your_custom_api_key"
 
 ```
+
+The legacy `LLM_SOURCE`, `CUSTOM_MODEL_BASE_URL`, and `CUSTOM_MODEL_API_KEY`
+names are still accepted as aliases. If both forms are set, the canonical
+`BIOMNI_*` variable takes precedence.
 </details>
 
 

--- a/biomni/config.py
+++ b/biomni/config.py
@@ -68,12 +68,18 @@ class BiomniConfig:
             self.commercial_mode = os.getenv("BIOMNI_COMMERCIAL_MODE").lower() == "true"
         if os.getenv("BIOMNI_TEMPERATURE"):
             self.temperature = float(os.getenv("BIOMNI_TEMPERATURE"))
-        if os.getenv("BIOMNI_CUSTOM_BASE_URL"):
-            self.base_url = os.getenv("BIOMNI_CUSTOM_BASE_URL")
-        if os.getenv("BIOMNI_CUSTOM_API_KEY"):
-            self.api_key = os.getenv("BIOMNI_CUSTOM_API_KEY")
-        if os.getenv("BIOMNI_SOURCE"):
-            self.source = os.getenv("BIOMNI_SOURCE")
+        # CUSTOM_MODEL_* and LLM_SOURCE were previously documented in the README
+        # and .env.example. Keep them as aliases while preferring BIOMNI_* when
+        # both spellings are set.
+        custom_base_url = os.getenv("BIOMNI_CUSTOM_BASE_URL") or os.getenv("CUSTOM_MODEL_BASE_URL")
+        if custom_base_url:
+            self.base_url = custom_base_url
+        custom_api_key = os.getenv("BIOMNI_CUSTOM_API_KEY") or os.getenv("CUSTOM_MODEL_API_KEY")
+        if custom_api_key:
+            self.api_key = custom_api_key
+        source = os.getenv("BIOMNI_SOURCE") or os.getenv("LLM_SOURCE")
+        if source:
+            self.source = source
 
         # Protocols.io access token (prefer specific env vars)
         env_token = os.getenv("PROTOCOLS_IO_ACCESS_TOKEN") or os.getenv("BIOMNI_PROTOCOLS_IO_ACCESS_TOKEN")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,10 @@ BIOMNI_CUSTOM_BASE_URL=http://localhost:8000/v1
 BIOMNI_CUSTOM_API_KEY=custom_key
 ```
 
+For backward compatibility, `LLM_SOURCE`, `CUSTOM_MODEL_BASE_URL`, and
+`CUSTOM_MODEL_API_KEY` are accepted as aliases. The canonical `BIOMNI_*`
+spelling takes precedence when both forms are present.
+
 ### Python Configuration
 
 ```python

--- a/tests/test_config_environment.py
+++ b/tests/test_config_environment.py
@@ -1,0 +1,109 @@
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from biomni.config import BiomniConfig
+
+REPO_ROOT = Path(__file__).parents[1]
+CUSTOM_ENV_NAMES = (
+    "BIOMNI_CUSTOM_BASE_URL",
+    "CUSTOM_MODEL_BASE_URL",
+    "BIOMNI_CUSTOM_API_KEY",
+    "CUSTOM_MODEL_API_KEY",
+    "BIOMNI_SOURCE",
+    "LLM_SOURCE",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_custom_provider_environment(monkeypatch):
+    for name in CUSTOM_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_canonical_custom_provider_environment(monkeypatch):
+    monkeypatch.setenv("BIOMNI_CUSTOM_BASE_URL", "https://canonical.example/v1")
+    monkeypatch.setenv("BIOMNI_CUSTOM_API_KEY", "canonical-key")
+    monkeypatch.setenv("BIOMNI_SOURCE", "Custom")
+
+    config = BiomniConfig()
+
+    assert config.base_url == "https://canonical.example/v1"
+    assert config.api_key == "canonical-key"
+    assert config.source == "Custom"
+
+
+def test_legacy_documented_names_remain_compatible(monkeypatch):
+    monkeypatch.setenv("CUSTOM_MODEL_BASE_URL", "https://legacy.example/v1")
+    monkeypatch.setenv("CUSTOM_MODEL_API_KEY", "legacy-key")
+    monkeypatch.setenv("LLM_SOURCE", "Custom")
+
+    config = BiomniConfig()
+
+    assert config.base_url == "https://legacy.example/v1"
+    assert config.api_key == "legacy-key"
+    assert config.source == "Custom"
+
+
+def test_canonical_names_take_precedence_over_aliases(monkeypatch):
+    monkeypatch.setenv("BIOMNI_CUSTOM_BASE_URL", "https://canonical.example/v1")
+    monkeypatch.setenv("CUSTOM_MODEL_BASE_URL", "https://legacy.example/v1")
+    monkeypatch.setenv("BIOMNI_CUSTOM_API_KEY", "canonical-key")
+    monkeypatch.setenv("CUSTOM_MODEL_API_KEY", "legacy-key")
+    monkeypatch.setenv("BIOMNI_SOURCE", "Custom")
+    monkeypatch.setenv("LLM_SOURCE", "Groq")
+
+    config = BiomniConfig()
+
+    assert config.base_url == "https://canonical.example/v1"
+    assert config.api_key == "canonical-key"
+    assert config.source == "Custom"
+
+
+def test_fresh_process_default_config_loads_legacy_aliases():
+    environment = os.environ.copy()
+    for name in CUSTOM_ENV_NAMES:
+        environment.pop(name, None)
+    environment.update(
+        {
+            "CUSTOM_MODEL_BASE_URL": "https://legacy.example/v1",
+            "CUSTOM_MODEL_API_KEY": "legacy-key",
+            "LLM_SOURCE": "Custom",
+        }
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import json; from biomni.config import default_config; print(json.dumps(default_config.to_dict()))",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    config = json.loads(completed.stdout)
+
+    assert config["base_url"] == "https://legacy.example/v1"
+    assert config["api_key"] == "legacy-key"
+    assert config["source"] == "Custom"
+
+
+def test_example_files_use_names_read_by_config():
+    assignment_pattern = re.compile(r"^\s*(?:#\s*)?(?:export\s+)?([A-Z][A-Z0-9_]+)=", re.MULTILINE)
+    env_example_names = set(assignment_pattern.findall((REPO_ROOT / ".env.example").read_text()))
+    readme_names = set(assignment_pattern.findall((REPO_ROOT / "README.md").read_text()))
+    canonical_names = {
+        "BIOMNI_SOURCE",
+        "BIOMNI_LLM",
+        "BIOMNI_CUSTOM_BASE_URL",
+        "BIOMNI_CUSTOM_API_KEY",
+    }
+
+    assert canonical_names <= env_example_names
+    assert canonical_names <= readme_names


### PR DESCRIPTION
## Summary

Fix the custom-provider environment-variable mismatch reported in #310.

The documented names previously had no effect because `.env.example` and the README used:

- `LLM_SOURCE`
- `CUSTOM_MODEL_BASE_URL`
- `CUSTOM_MODEL_API_KEY`

while `BiomniConfig` only read `BIOMNI_SOURCE`, `BIOMNI_CUSTOM_BASE_URL`, and `BIOMNI_CUSTOM_API_KEY`.

## Changes

- make `.env.example`, the README `.env` example, and shell-export example use the canonical `BIOMNI_*` names
- document the custom model name (`BIOMNI_LLM`) alongside the endpoint, key, and source
- retain all three previously documented names as backward-compatible aliases
- prefer canonical `BIOMNI_*` values when both forms are set
- document alias precedence in the README and configuration guide

The aliases matter for users who copied an older README. They also fix the issue's secondary failure mode: tools that call `get_llm()` internally read the global `default_config`, so constructor-only `A1(...)` overrides were not sufficient.

## Testing

```text
uv run --python 3.11 --with pytest python -m pytest -q tests/test_config_environment.py
5 passed
```

The tests cover canonical variables, legacy aliases, canonical precedence, documented assignments, and a fresh Python process importing the global `default_config` with only legacy variables set.

All repository pre-commit hooks pass for the five changed files.

## AI assistance

OpenAI Codex assisted with implementation and test development. I reviewed the changes and verified them with isolated environment tests, a fresh-process regression test, Ruff, compilation, and repository pre-commit hooks.

Closes #310
