### PR TITLE
Fix observation tag mismatch in agent prompt

### DIFF
--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -1121,7 +1121,7 @@ Always show the updated plan after each step so the user can track progress.
 At each turn, you should first provide your thinking and reasoning given the conversation history.
 After that, you have two options:
 
-1) Interact with a programming environment and receive the corresponding output within <observe></observe>. Your code should be enclosed using "<execute>" tag, for example: <execute> print("Hello World!") </execute>. IMPORTANT: You must end the code block with </execute> tag.
+1) Interact with a programming environment and receive the corresponding output within <observation></observation>. Your code should be enclosed using "<execute>" tag, for example: <execute> print("Hello World!") </execute>. IMPORTANT: You must end the code block with </execute> tag.
    - For Python code (default): <execute> print("Hello World!") </execute>
    - For R code: <execute> #!R\nlibrary(ggplot2)\nprint("Hello from R") </execute>
    - For Bash scripts and commands: <execute> #!BASH\necho "Hello from Bash"\nls -la </execute>


### PR DESCRIPTION
## Summary\n\n- align the agent prompt with the runtime observation protocol\n- replace the unsupported <observe> wrapper with <observation>\n- resolve #258\n\nThe executor, parser, formatter, and conversation cleanup paths all use <observation>; this removes the only conflicting instruction.\n\n## Validation\n\n- python3 -m py_compile biomni/agent/a1.py\n- uvx pre-commit run --all-files\n- verified there are no remaining <observe> references in biomni/agent/a1.py or biomni/utils.py\n\nAI assistance: This change and PR description were prepared with OpenAI Codex; I reviewed and validated the final diff.