### PR TITLE
Fix Cellpose 4 segmentation and output handling

### DIFF
--- a/biomni/tool/microbiology.py
+++ b/biomni/tool/microbiology.py
@@ -1112,152 +1112,188 @@ Output files:
 
 def segment_cells_with_deep_learning(
     image_path,
-    model_type="bact_fluor_omni",
+    model_type="cpsam",
     diameter=None,
     save_dir="segmentation_results",
+    use_gpu=False,
+    channel_axis=None,
+    flow_threshold=0.4,
+    cellprob_threshold=0.0,
+    min_size=15,
 ):
-    """Perform cell segmentation on fluorescence microscopy images using deep learning.
-
-    Uses pre-trained models from the Cellpose/Omnipose library to identify and segment
-    individual cells in fluorescence microscopy images.
+    """Segment cells in a 2D microscopy image with Cellpose 4.
 
     Parameters
     ----------
     image_path : str
-        Path to the fluorescence microscopy image file
+        Path to a 2D grayscale or multichannel microscopy image.
     model_type : str, optional
-        Name of the pre-trained model to use (default: 'bact_fluor_omni')
-        Options include: 'bact_fluor_omni', 'cyto', 'nuclei', etc.
+        Cellpose 4 pretrained model name or model-file path. The built-in model
+        is cpsam.
     diameter : float, optional
-        Expected diameter of cells in pixels. If None, diameter is automatically estimated.
+        Cell diameter in pixels used to rescale the image. None keeps the
+        image at its native scale.
     save_dir : str, optional
-        Directory to save segmentation results (default: 'segmentation_results')
+        Directory for the label mask and boundary-overlay image.
+    use_gpu : bool, optional
+        Request a CUDA or MPS device through Cellpose.
+    channel_axis : int, optional
+        Channel axis for a multichannel image. It is inferred for common HWC
+        and CHW inputs when omitted.
+    flow_threshold : float, optional
+        Maximum flow error for retaining masks.
+    cellprob_threshold : float, optional
+        Cell-probability threshold used to create masks.
+    min_size : int, optional
+        Minimum mask size in pixels.
 
     Returns
     -------
     str
-        Research log detailing the segmentation process and results
+        Research log with segmentation settings, counts, statistics, and paths.
 
     """
     import os
     from datetime import datetime
+    from pathlib import Path
 
     import matplotlib.pyplot as plt
     import numpy as np
     from cellpose import models
     from skimage import io
+    from skimage.segmentation import find_boundaries
 
-    # Create output directory if it doesn't exist
     os.makedirs(save_dir, exist_ok=True)
 
-    # Start research log
     log = "# Cell Segmentation Research Log\n"
     log += f"Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-
-    # Load the image
     log += "## Loading Image\n"
     log += f"Image path: {image_path}\n"
 
     try:
-        img = io.imread(image_path)
-        log += f"Image loaded successfully. Shape: {img.shape}\n\n"
-    except Exception as e:
-        log += f"Error loading image: {str(e)}\n"
-        return log
+        image = io.imread(image_path)
+    except Exception as error:
+        return log + f"Error loading image: {error}\n"
 
-    # Prepare image for model
-    if len(img.shape) > 2 and img.shape[2] > 1:
-        # If RGB, convert to grayscale for single channel
-        img_model = img[:, :, 0] if img.shape[2] >= 3 else img
-        log += "Using first channel of multi-channel image for segmentation.\n\n"
-    else:
-        img_model = img
+    if image.ndim not in (2, 3):
+        return log + f"Error loading image: expected a 2D image with optional channels, got shape {image.shape}.\n"
 
-    # Initialize model
-    log += "## Initializing Model\n"
-    log += f"Model type: {model_type}\n"
-
-    try:
-        model = models.CellposeModel(model_type=model_type, gpu=False)
-        log += "Model initialized successfully.\n\n"
-    except Exception as e:
-        log += f"Error initializing model: {str(e)}\n"
-        return log
-
-    # Run segmentation
-    log += "## Performing Segmentation\n"
-
-    try:
-        channels = [0, 0]  # First channel for cell detection, no second channel
-
-        log += "Estimated cell diameter: "
-        if diameter is None:
-            log += "Auto-estimating\n"
+    resolved_channel_axis = channel_axis
+    if image.ndim == 2 and resolved_channel_axis is not None:
+        return log + "Error loading image: channel_axis must be None for a 2D grayscale image.\n"
+    if image.ndim == 3 and resolved_channel_axis is None:
+        if image.shape[-1] <= 4:
+            resolved_channel_axis = -1
+        elif image.shape[0] <= 4:
+            resolved_channel_axis = 0
         else:
-            log += f"{diameter} pixels\n"
+            return (
+                log + "Error loading image: cannot infer a channel axis. "
+                "Pass channel_axis for multichannel input; 3D volume segmentation is not supported.\n"
+            )
+    if resolved_channel_axis is not None and not -image.ndim <= resolved_channel_axis < image.ndim:
+        return log + f"Error loading image: channel_axis {resolved_channel_axis} is invalid for shape {image.shape}.\n"
 
-        # Adjust the unpacking based on the expected return values
-        results = model.eval(
-            img_model,
-            diameter=diameter,
-            channels=channels,
-            flow_threshold=0.4,
-            do_3D=False,
+    log += f"Image loaded successfully. Shape: {image.shape}\n"
+    log += f"Channel axis: {resolved_channel_axis}\n\n"
+
+    pretrained_model = os.fspath(model_type)
+    available_models = set(getattr(models, "MODEL_NAMES", []))
+    get_user_models = getattr(models, "get_user_models", None)
+    if callable(get_user_models):
+        available_models.update(get_user_models())
+    if not os.path.isfile(pretrained_model) and pretrained_model not in available_models:
+        available = ", ".join(sorted(available_models)) or "none"
+        return log + (
+            f"Error initializing model: unknown model {pretrained_model!r}. "
+            f"Available Cellpose models: {available}; a model-file path is also accepted.\n"
         )
 
-        # Check the number of returned values
-        if len(results) == 3:
-            masks, flows, diams = results  # Adjusted for 3 return values
-            styles = None  # If styles are not returned, set to None
-        elif len(results) == 4:
-            masks, flows, styles, diams = results  # Original unpacking
+    log += "## Initializing Model\n"
+    log += f"Pretrained model: {pretrained_model}\n"
+    log += f"GPU requested: {use_gpu}\n"
+    try:
+        model = models.CellposeModel(pretrained_model=pretrained_model, gpu=use_gpu)
+    except Exception as error:
+        return log + f"Error initializing model: {error}\n"
+    log += "Model initialized successfully.\n\n"
+
+    log += "## Performing Segmentation\n"
+    if diameter is None:
+        log += "Diameter: native image scale (no rescaling)\n"
+    else:
+        log += f"Diameter: {diameter} pixels\n"
+    log += f"Flow threshold: {flow_threshold}\n"
+    log += f"Cell-probability threshold: {cellprob_threshold}\n"
+    log += f"Minimum mask size: {min_size} pixels\n"
+
+    try:
+        results = model.eval(
+            image,
+            diameter=diameter,
+            channel_axis=resolved_channel_axis,
+            flow_threshold=flow_threshold,
+            cellprob_threshold=cellprob_threshold,
+            min_size=min_size,
+            do_3D=False,
+        )
+        if not isinstance(results, tuple) or len(results) != 3:
+            length = len(results) if hasattr(results, "__len__") else "unknown"
+            raise ValueError(f"Cellpose 4 model.eval() must return 3 values, got {length}")
+        masks, _flows, _styles = results
+        masks = np.asarray(masks)
+        if resolved_channel_axis is None:
+            expected_shape = image.shape
         else:
-            raise ValueError(f"Unexpected number of return values from model.eval(): {len(results)}")
+            normalized_axis = resolved_channel_axis % image.ndim
+            expected_shape = tuple(size for axis, size in enumerate(image.shape) if axis != normalized_axis)
+        if masks.ndim != 2 or tuple(masks.shape) != tuple(expected_shape):
+            raise ValueError(f"mask shape {masks.shape} does not match image plane {tuple(expected_shape)}")
+    except Exception as error:
+        return log + f"Error during segmentation: {error}\n"
 
-        if diameter is None:
-            log += f"Auto-estimated cell diameter: {diams[0]:.2f} pixels\n"
+    labels = np.unique(masks)
+    labels = labels[labels != 0]
+    cell_count = len(labels)
+    log += f"Segmentation complete. Detected {cell_count} cells.\n\n"
 
-        cell_count = len(np.unique(masks)) - 1  # Subtract 1 for background
-        log += f"Segmentation complete. Detected {cell_count} cells.\n\n"
-    except Exception as e:
-        log += f"Error during segmentation: {str(e)}\n"
-        return log
+    stem = Path(image_path).stem
+    mask_file = os.path.join(save_dir, f"{stem}_masks.tif")
+    outline_file = os.path.join(save_dir, f"{stem}_outlines.png")
 
-    # Save results
     log += "## Saving Results\n"
+    try:
+        io.imsave(mask_file, masks.astype(np.uint32), check_contrast=False)
 
-    # Save mask image
-    mask_file = os.path.join(save_dir, f"masks_{os.path.basename(image_path)}")
-    io.imsave(mask_file, masks.astype(np.uint16))
+        display_image = image
+        if resolved_channel_axis is not None:
+            display_image = np.moveaxis(image, resolved_channel_axis, -1)
+            if display_image.shape[-1] == 1:
+                display_image = display_image[..., 0]
+            elif display_image.shape[-1] > 3:
+                display_image = display_image[..., :3]
+
+        boundaries = find_boundaries(masks, mode="outer")
+        overlay = np.zeros((*masks.shape, 4), dtype=float)
+        overlay[boundaries] = (1.0, 0.0, 0.0, 1.0)
+
+        figure, axis = plt.subplots(figsize=(10, 8))
+        axis.imshow(display_image, cmap="gray" if display_image.ndim == 2 else None)
+        axis.imshow(overlay, interpolation="none")
+        axis.axis("off")
+        figure.savefig(outline_file, bbox_inches="tight", pad_inches=0)
+        plt.close(figure)
+    except Exception as error:
+        return log + f"Error saving segmentation results: {error}\n"
+
     log += f"Cell masks saved to: {mask_file}\n"
-
-    # Create and save outlines image
-    plt.figure(figsize=(10, 8))
-    plt.imshow(img_model, cmap="gray")
-
-    # Generate outlines from masks
-    from skimage.segmentation import find_boundaries
-
-    find_boundaries(masks, mode="outer")
-    plt.contour(masks, levels=np.unique(masks), colors="r", linewidths=0.5)
-
-    outline_file = os.path.join(save_dir, f"outlines_{os.path.basename(image_path)}")
-    plt.axis("off")
-    plt.savefig(outline_file, bbox_inches="tight", pad_inches=0)
-    plt.close()
-    log += f"Cell outlines overlaid on original image saved to: {outline_file}\n\n"
-
-    # Final statistics
+    log += f"Cell outlines saved to: {outline_file}\n\n"
     log += "## Segmentation Statistics\n"
     log += f"Total cells detected: {cell_count}\n"
-
-    # Calculate additional metrics
-    if cell_count > 0:
-        cell_areas = [np.sum(masks == i) for i in range(1, cell_count + 1)]
-        avg_cell_area = np.mean(cell_areas)
-        std_cell_area = np.std(cell_areas)
-        log += f"Average cell area: {avg_cell_area:.2f} pixels\n"
-        log += f"Standard deviation of cell area: {std_cell_area:.2f} pixels\n"
+    if cell_count:
+        cell_areas = [np.count_nonzero(masks == label) for label in labels]
+        log += f"Average cell area: {np.mean(cell_areas):.2f} pixels\n"
+        log += f"Standard deviation of cell area: {np.std(cell_areas):.2f} pixels\n"
 
     return log
 

--- a/biomni/tool/tool_description/microbiology.py
+++ b/biomni/tool/tool_description/microbiology.py
@@ -302,23 +302,19 @@ description = [
         ],
     },
     {
-        "description": "Perform cell segmentation on fluorescence microscopy images "
-        "using deep learning with pre-trained models from the "
-        "Cellpose/Omnipose library.",
+        "description": "Segment 2D grayscale or multichannel microscopy images "
+        "with Cellpose 4 and report cell morphology statistics.",
         "name": "segment_cells_with_deep_learning",
         "optional_parameters": [
             {
-                "default": "bact_fluor_omni",
-                "description": "Name of the pre-trained model to "
-                "use (Options include: "
-                "'bact_fluor_omni', 'cyto', "
-                "'nuclei', etc.)",
+                "default": "cpsam",
+                "description": "Cellpose 4 pre-trained model name or path to a model file",
                 "name": "model_type",
                 "type": "str",
             },
             {
                 "default": None,
-                "description": "Expected diameter of cells in pixels. If None, diameter is automatically estimated",
+                "description": "Cell diameter in pixels for image rescaling. None keeps the native image scale",
                 "name": "diameter",
                 "type": "float",
             },
@@ -327,6 +323,36 @@ description = [
                 "description": "Directory to save segmentation results",
                 "name": "save_dir",
                 "type": "str",
+            },
+            {
+                "default": False,
+                "description": "Request a CUDA or MPS device through Cellpose",
+                "name": "use_gpu",
+                "type": "bool",
+            },
+            {
+                "default": None,
+                "description": "Channel axis for multichannel input; inferred for common HWC and CHW images",
+                "name": "channel_axis",
+                "type": "int",
+            },
+            {
+                "default": 0.4,
+                "description": "Maximum flow error for retaining masks",
+                "name": "flow_threshold",
+                "type": "float",
+            },
+            {
+                "default": 0.0,
+                "description": "Cell-probability threshold used to create masks",
+                "name": "cellprob_threshold",
+                "type": "float",
+            },
+            {
+                "default": 15,
+                "description": "Minimum mask size in pixels",
+                "name": "min_size",
+                "type": "int",
             },
         ],
         "required_parameters": [

--- a/tests/test_cellpose_segmentation.py
+++ b/tests/test_cellpose_segmentation.py
@@ -1,0 +1,173 @@
+import inspect
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import numpy as np
+from biomni.tool.microbiology import segment_cells_with_deep_learning
+from biomni.tool.tool_description.microbiology import description
+from skimage import io
+
+
+class FakeCellposeModel:
+    instances = []
+    eval_result = None
+
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+        self.eval_calls = []
+        self.__class__.instances.append(self)
+
+    def eval(self, image, **kwargs):
+        self.eval_calls.append((image, kwargs))
+        if self.__class__.eval_result is not None:
+            return self.__class__.eval_result
+
+        channel_axis = kwargs["channel_axis"]
+        plane_shape = list(image.shape)
+        if channel_axis is not None:
+            plane_shape.pop(channel_axis % image.ndim)
+        masks = np.zeros(plane_shape, dtype=np.int32)
+        masks[1:3, 1:4] = 1
+        masks[4:6, 5:8] = 3
+        return masks, {"flow": "unused"}, np.array([0.25, 0.75])
+
+
+def fake_cellpose_module():
+    models = types.SimpleNamespace(
+        CellposeModel=FakeCellposeModel,
+        MODEL_NAMES=["cpsam"],
+        get_user_models=lambda: ["custom-model"],
+    )
+    return types.SimpleNamespace(models=models)
+
+
+class CellposeSegmentationTest(unittest.TestCase):
+    def setUp(self):
+        FakeCellposeModel.instances = []
+        FakeCellposeModel.eval_result = None
+        self.cellpose_patch = mock.patch.dict(sys.modules, {"cellpose": fake_cellpose_module()})
+        self.cellpose_patch.start()
+
+    def tearDown(self):
+        self.cellpose_patch.stop()
+
+    def test_cellpose_4_rgb_segmentation_and_outputs(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_path = root / "rgb.png"
+            save_dir = root / "results"
+            image = np.zeros((8, 9, 3), dtype=np.uint8)
+            image[..., 1] = 100
+            io.imsave(image_path, image, check_contrast=False)
+
+            log = segment_cells_with_deep_learning(
+                image_path,
+                save_dir=save_dir,
+                use_gpu=True,
+                flow_threshold=0.5,
+                cellprob_threshold=-0.25,
+                min_size=7,
+            )
+
+            self.assertIn("Detected 2 cells", log)
+            self.assertIn("native image scale (no rescaling)", log)
+            self.assertNotIn("automatically estimated", log)
+            model = FakeCellposeModel.instances[0]
+            self.assertEqual(model.init_kwargs, {"pretrained_model": "cpsam", "gpu": True})
+            evaluated_image, eval_kwargs = model.eval_calls[0]
+            np.testing.assert_array_equal(evaluated_image, image)
+            self.assertEqual(
+                eval_kwargs,
+                {
+                    "diameter": None,
+                    "channel_axis": -1,
+                    "flow_threshold": 0.5,
+                    "cellprob_threshold": -0.25,
+                    "min_size": 7,
+                    "do_3D": False,
+                },
+            )
+
+            mask = io.imread(save_dir / "rgb_masks.tif")
+            self.assertEqual(set(np.unique(mask)), {0, 1, 3})
+            self.assertEqual(mask.shape, image.shape[:2])
+            self.assertTrue((save_dir / "rgb_outlines.png").is_file())
+
+    def test_infers_channel_first_input(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_path = root / "channel-first.tif"
+            image = np.zeros((2, 8, 9), dtype=np.uint8)
+            io.imsave(image_path, image, check_contrast=False)
+
+            log = segment_cells_with_deep_learning(image_path, save_dir=root / "results")
+
+            self.assertIn("Channel axis: 0", log)
+            _, eval_kwargs = FakeCellposeModel.instances[0].eval_calls[0]
+            self.assertEqual(eval_kwargs["channel_axis"], 0)
+
+    def test_rejects_unknown_model_instead_of_silently_falling_back(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_path = root / "gray.tif"
+            io.imsave(image_path, np.zeros((8, 9), dtype=np.uint8), check_contrast=False)
+
+            log = segment_cells_with_deep_learning(
+                image_path,
+                model_type="bact_fluor_omni",
+                save_dir=root / "results",
+            )
+
+            self.assertIn("unknown model 'bact_fluor_omni'", log)
+            self.assertIn("cpsam", log)
+            self.assertEqual(FakeCellposeModel.instances, [])
+
+    def test_rejects_ambiguous_volume_and_channel_axis_on_grayscale(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            volume_path = root / "volume.tif"
+            gray_path = root / "gray.tif"
+            io.imsave(volume_path, np.zeros((5, 6, 7), dtype=np.uint8), check_contrast=False)
+            io.imsave(gray_path, np.zeros((8, 9), dtype=np.uint8), check_contrast=False)
+
+            volume_log = segment_cells_with_deep_learning(volume_path, save_dir=root / "volume-results")
+            gray_log = segment_cells_with_deep_learning(
+                gray_path,
+                channel_axis=0,
+                save_dir=root / "gray-results",
+            )
+
+            self.assertIn("cannot infer a channel axis", volume_log)
+            self.assertIn("channel_axis must be None", gray_log)
+            self.assertEqual(FakeCellposeModel.instances, [])
+
+    def test_rejects_non_v4_eval_result(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_path = root / "gray.tif"
+            io.imsave(image_path, np.zeros((8, 9), dtype=np.uint8), check_contrast=False)
+            FakeCellposeModel.eval_result = (np.zeros((8, 9)), {"flow": "unused"})
+
+            log = segment_cells_with_deep_learning(image_path, save_dir=root / "results")
+
+            self.assertIn("Cellpose 4 model.eval() must return 3 values, got 2", log)
+
+    def test_tool_description_matches_function_signature(self):
+        tool = next(item for item in description if item["name"] == "segment_cells_with_deep_learning")
+        schema_defaults = {item["name"]: item["default"] for item in tool["optional_parameters"]}
+        function_defaults = {
+            name: parameter.default
+            for name, parameter in inspect.signature(segment_cells_with_deep_learning).parameters.items()
+            if parameter.default is not inspect.Parameter.empty
+        }
+
+        self.assertEqual(schema_defaults, function_defaults)
+        self.assertEqual(schema_defaults["model_type"], "cpsam")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- update `segment_cells_with_deep_learning` for the Cellpose 4.0.6 API pinned by Biomni
- replace the removed bacterial Omnipose default with the supported `cpsam` model and reject unknown model names instead of allowing Cellpose to silently fall back
- preserve multichannel input, expose current segmentation controls, handle the three-value `(masks, flows, styles)` result correctly, and save lossless label masks plus actual boundary overlays
- keep the tool description synchronized with the function signature and add regression coverage

## Problem

Biomni pins `cellpose==4.0.6`, but this tool still passes `model_type="bact_fluor_omni"`. Cellpose 4.0.6 warns that `model_type` is ignored in v4.0.1+, and an unknown `pretrained_model` silently falls back to `cpsam`. The current tool also interprets the third `eval()` result as diameters even though Cellpose 4 returns styles, and says `diameter=None` auto-estimates size although v4 runs at native scale.

The pinned API behavior is visible in the [Cellpose 4.0.6 model source](https://github.com/MouseLand/cellpose/blob/v4.0.6/cellpose/models.py). This PR advances #202 using the version already present in Biomni.

## Verification

- `MPLBACKEND=Agg uv run --python 3.11 --with numpy --with matplotlib --with scikit-image --with pandas --with requests --with tqdm python -m unittest tests/test_cellpose_segmentation.py -v` — 6 tests pass
- `uvx pre-commit run --all-files` — all hooks pass
- tests exercise RGB and channel-first images, Cellpose 4 constructor/eval arguments and return arity, unknown-model rejection, ambiguous volume rejection, non-contiguous mask labels, readable TIFF/PNG outputs, and schema/signature parity

The tests use a deterministic Cellpose 4 API stub so they do not download the large model weights. Image loading, TIFF mask writing, PNG overlay writing, and result reloading use the real NumPy/scikit-image/matplotlib stack.

## Agent test prompt

> Segment the cells in `/path/to/microscopy_image.tif` with the Cellpose 4 cpsam model at native image scale, save the masks and boundary overlay under `/tmp/cellpose-results`, and report the detected-cell count and area statistics.

## AI assistance disclosure

This contribution was implemented and tested with assistance from OpenAI Codex. I reviewed the final diff and verified it against the Cellpose 4.0.6 source and the tests above.