### PR TITLE
Add CIViC mutation-aware evidence retrieval tool

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -1904,6 +1904,298 @@ def query_clinvar(
     )
 
 
+def query_civic(
+    gene,
+    variant,
+    disease=None,
+    evidence_type=None,
+    evidence_status="ACCEPTED",
+    max_results=25,
+    max_variants=5,
+):
+    """Retrieve curated cancer-variant evidence from the public CIViC GraphQL API.
+
+    Parameters
+    ----------
+    gene : str
+        HGNC gene symbol, such as ``KRAS`` or ``TP53``.
+    variant : str
+        CIViC variant name or alias, such as ``G12D``, ``p.G12D``, or
+        ``GLY12ASP``. A leading gene symbol is removed automatically.
+    disease : str, optional
+        Disease-name filter, such as ``pancreatic``.
+    evidence_type : str, optional
+        CIViC evidence type: DIAGNOSTIC, PROGNOSTIC, PREDICTIVE,
+        PREDISPOSING, FUNCTIONAL, or ONCOGENIC.
+    evidence_status : str, optional
+        CIViC curation status. Defaults to ACCEPTED. Other supported values are
+        SUBMITTED, REJECTED, NON_REJECTED, and ALL.
+    max_results : int, optional
+        Maximum number of evidence items to return across matched variants.
+    max_variants : int, optional
+        Maximum number of variants to follow when an alias matches more than
+        one CIViC variant.
+
+    Returns
+    -------
+    dict
+        Matched variants and structured CIViC evidence with source citations,
+        curation status, evidence level, rating, direction, and significance.
+
+    """
+    api_url = "https://civicdb.org/api/graphql"
+    civic_url = "https://civicdb.org"
+    allowed_evidence_types = {
+        "DIAGNOSTIC",
+        "FUNCTIONAL",
+        "ONCOGENIC",
+        "PREDICTIVE",
+        "PREDISPOSING",
+        "PROGNOSTIC",
+    }
+    allowed_statuses = {"ACCEPTED", "ALL", "NON_REJECTED", "REJECTED", "SUBMITTED"}
+
+    if not isinstance(gene, str) or not gene.strip():
+        return {"error": "gene must be a non-empty HGNC symbol"}
+    if not isinstance(variant, str) or not variant.strip():
+        return {"error": "variant must be a non-empty CIViC variant name or alias"}
+    if disease is not None and (not isinstance(disease, str) or not disease.strip()):
+        return {"error": "disease must be a non-empty string when provided"}
+    if isinstance(max_results, bool) or not isinstance(max_results, int) or not 1 <= max_results <= 100:
+        return {"error": "max_results must be an integer between 1 and 100"}
+    if isinstance(max_variants, bool) or not isinstance(max_variants, int) or not 1 <= max_variants <= 20:
+        return {"error": "max_variants must be an integer between 1 and 20"}
+
+    normalized_gene = gene.strip().upper()
+    normalized_variant = variant.strip()
+    if normalized_variant.upper().startswith(f"{normalized_gene} "):
+        normalized_variant = normalized_variant[len(normalized_gene) :].strip()
+    if normalized_variant.lower().startswith("p."):
+        normalized_variant = normalized_variant[2:].strip()
+    if not normalized_variant:
+        return {"error": "variant must contain a value after removing the gene symbol or p. prefix"}
+
+    normalized_evidence_type = None
+    if evidence_type is not None:
+        if not isinstance(evidence_type, str):
+            return {"error": "evidence_type must be a string when provided"}
+        normalized_evidence_type = evidence_type.strip().upper().replace("-", "_").replace(" ", "_")
+        if normalized_evidence_type not in allowed_evidence_types:
+            allowed = ", ".join(sorted(allowed_evidence_types))
+            return {"error": f"Unsupported evidence_type. Choose one of: {allowed}"}
+
+    if not isinstance(evidence_status, str):
+        return {"error": "evidence_status must be a string"}
+    normalized_status = evidence_status.strip().upper().replace("-", "_").replace(" ", "_")
+    if normalized_status not in allowed_statuses:
+        allowed = ", ".join(sorted(allowed_statuses))
+        return {"error": f"Unsupported evidence_status. Choose one of: {allowed}"}
+
+    def run_graphql(query, variables, description):
+        response = _query_rest_api(
+            endpoint=api_url,
+            method="POST",
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            json_data={"query": query, "variables": variables},
+            description=description,
+        )
+        if not response.get("success", False):
+            return response
+
+        payload = response.get("result")
+        if not isinstance(payload, dict):
+            return {"success": False, "error": "CIViC returned a non-object GraphQL response"}
+        if payload.get("errors"):
+            messages = [
+                str(error.get("message", error) if isinstance(error, dict) else error) for error in payload["errors"]
+            ]
+            return {"success": False, "error": f"CIViC GraphQL error: {'; '.join(messages)}"}
+        if not isinstance(payload.get("data"), dict):
+            return {"success": False, "error": "CIViC GraphQL response did not contain data"}
+        return {"success": True, "data": payload["data"]}
+
+    variant_query = """
+    query CivicVariants($gene: String!, $variant: String!, $first: Int!) {
+      gene(entrezSymbol: $gene) {
+        id
+        name
+        entrezId
+        link
+        variants(name: $variant, first: $first) {
+          totalCount
+          nodes { id name link variantAliases }
+        }
+      }
+    }
+    """
+    variant_response = run_graphql(
+        variant_query,
+        {"gene": normalized_gene, "variant": normalized_variant, "first": max_variants},
+        f"Find CIViC variants for {normalized_gene} {normalized_variant}",
+    )
+    if not variant_response.get("success", False):
+        return variant_response
+
+    gene_record = variant_response["data"].get("gene")
+    if gene_record is None:
+        return {
+            "database": "CIViC",
+            "query": {"gene": normalized_gene, "variant": normalized_variant},
+            "error": f"Gene {normalized_gene!r} was not found in CIViC",
+            "matched_variants": [],
+            "evidence_items": [],
+        }
+
+    variant_connection = gene_record.get("variants") or {}
+    matched_variants = variant_connection.get("nodes") or []
+    total_matching_variants = variant_connection.get("totalCount", len(matched_variants))
+    gene_result = {
+        "id": gene_record.get("id"),
+        "name": gene_record.get("name"),
+        "entrez_id": gene_record.get("entrezId"),
+        "url": f"{civic_url}{gene_record.get('link', '')}",
+    }
+    if not matched_variants:
+        return {
+            "database": "CIViC",
+            "query": {"gene": normalized_gene, "variant": normalized_variant},
+            "gene": gene_result,
+            "total_matching_variants": 0,
+            "matched_variants": [],
+            "total_evidence_for_returned_variants": 0,
+            "returned_evidence": 0,
+            "evidence_items": [],
+            "note": "No CIViC variant name or alias matched the normalized query.",
+        }
+
+    optional_declarations = ""
+    optional_arguments = ""
+    if disease is not None:
+        optional_declarations += "      $disease: String\n"
+        optional_arguments += "        diseaseName: $disease\n"
+    if normalized_evidence_type is not None:
+        optional_declarations += "      $evidenceType: EvidenceType\n"
+        optional_arguments += "        evidenceType: $evidenceType\n"
+
+    evidence_query = (
+        """
+    query CivicEvidence(
+      $variantId: Int!
+"""
+        + optional_declarations
+        + """      $status: EvidenceStatusFilter!
+      $first: Int!
+    ) {
+      evidenceItems(
+        variantId: $variantId
+"""
+        + optional_arguments
+        + """        status: $status
+        sortBy: {column: EVIDENCE_RATING, direction: DESC}
+        first: $first
+      ) {
+        totalCount
+        nodes {
+          id name link status description evidenceType evidenceLevel
+          evidenceRating evidenceDirection significance variantOrigin
+          disease { id doid name displayName }
+          therapies { id name ncitId }
+          source { sourceType citationId pmcId title }
+        }
+      }
+    }
+    """
+    )
+
+    evidence_items = []
+    total_evidence = 0
+    returned_variants = []
+    for matched_variant in matched_variants:
+        remaining = max_results - len(evidence_items)
+        if remaining <= 0:
+            break
+        evidence_variables = {
+            "variantId": matched_variant["id"],
+            "status": normalized_status,
+            "first": remaining,
+        }
+        if disease is not None:
+            evidence_variables["disease"] = disease.strip()
+        if normalized_evidence_type is not None:
+            evidence_variables["evidenceType"] = normalized_evidence_type
+        evidence_response = run_graphql(
+            evidence_query,
+            evidence_variables,
+            f"Retrieve CIViC evidence for variant {matched_variant['id']}",
+        )
+        if not evidence_response.get("success", False):
+            return evidence_response
+
+        evidence_connection = evidence_response["data"].get("evidenceItems") or {}
+        variant_total = evidence_connection.get("totalCount", 0)
+        total_evidence += variant_total
+        returned_variant = {
+            "id": matched_variant.get("id"),
+            "name": matched_variant.get("name"),
+            "aliases": matched_variant.get("variantAliases") or [],
+            "url": f"{civic_url}{matched_variant.get('link', '')}",
+            "matching_evidence": variant_total,
+        }
+        returned_variants.append(returned_variant)
+
+        for item in evidence_connection.get("nodes") or []:
+            source = item.get("source") or {}
+            citation_id = source.get("citationId")
+            pmc_id = source.get("pmcId")
+            item["url"] = f"{civic_url}{item.pop('link', '')}"
+            item["variant"] = {
+                "id": returned_variant["id"],
+                "name": returned_variant["name"],
+                "url": returned_variant["url"],
+            }
+            if citation_id:
+                source["pubmed_url"] = f"https://pubmed.ncbi.nlm.nih.gov/{citation_id}/"
+            if pmc_id:
+                source["pmc_url"] = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmc_id}/"
+            evidence_items.append(item)
+
+    notes = [
+        "CIViC evidence is community curated and should be interpreted with its status, level, rating, and source.",
+        "Results are educational evidence records, not clinical recommendations.",
+    ]
+    if normalized_status != "ACCEPTED":
+        notes.append(
+            f"The query requested {normalized_status} evidence; non-accepted records may be unreviewed or rejected."
+        )
+    if total_matching_variants > len(returned_variants):
+        notes.append(
+            f"The alias matched {total_matching_variants} variants; only the first {len(returned_variants)} were queried."
+        )
+    if total_evidence > len(evidence_items):
+        notes.append(
+            f"The filters matched {total_evidence} evidence items; max_results returned {len(evidence_items)}."
+        )
+
+    return {
+        "database": "CIViC",
+        "api_url": api_url,
+        "query": {
+            "gene": normalized_gene,
+            "variant": normalized_variant,
+            "disease": disease.strip() if disease is not None else None,
+            "evidence_type": normalized_evidence_type,
+            "evidence_status": normalized_status,
+        },
+        "gene": gene_result,
+        "total_matching_variants": total_matching_variants,
+        "matched_variants": returned_variants,
+        "total_evidence_for_returned_variants": total_evidence,
+        "returned_evidence": len(evidence_items),
+        "evidence_items": evidence_items,
+        "notes": notes,
+    }
+
+
 def query_geo(
     prompt=None,
     search_term=None,

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -235,6 +235,57 @@ description = [
         ],
     },
     {
+        "description": "Retrieve curated cancer-variant evidence from CIViC by gene symbol and variant name or alias. "
+        "Returns source-linked evidence with curation status, level, rating, direction, and significance.",
+        "name": "query_civic",
+        "optional_parameters": [
+            {
+                "name": "disease",
+                "type": "str",
+                "description": "Optional disease-name filter, such as 'pancreatic'",
+                "default": None,
+            },
+            {
+                "name": "evidence_type",
+                "type": "str",
+                "description": "CIViC evidence type: DIAGNOSTIC, PROGNOSTIC, PREDICTIVE, PREDISPOSING, FUNCTIONAL, or ONCOGENIC",
+                "default": None,
+            },
+            {
+                "name": "evidence_status",
+                "type": "str",
+                "description": "CIViC curation status; ACCEPTED is the reviewed default",
+                "default": "ACCEPTED",
+            },
+            {
+                "name": "max_results",
+                "type": "int",
+                "description": "Maximum evidence items to return across matched variants (1-100)",
+                "default": 25,
+            },
+            {
+                "name": "max_variants",
+                "type": "int",
+                "description": "Maximum variants to query when an alias matches multiple CIViC variants (1-20)",
+                "default": 5,
+            },
+        ],
+        "required_parameters": [
+            {
+                "name": "gene",
+                "type": "str",
+                "description": "HGNC gene symbol, such as KRAS or TP53",
+                "default": None,
+            },
+            {
+                "name": "variant",
+                "type": "str",
+                "description": "CIViC variant name or alias, such as G12D, p.G12D, or GLY12ASP",
+                "default": None,
+            },
+        ],
+    },
+    {
         "description": "Query the NCBI GEO database (GDS/GEOPROFILES) using natural language or direct search term.",
         "name": "query_geo",
         "optional_parameters": [

--- a/tests/test_civic_query.py
+++ b/tests/test_civic_query.py
@@ -1,0 +1,205 @@
+import inspect
+import unittest
+from unittest import mock
+
+from biomni.tool.database import query_civic
+from biomni.tool.tool_description.database import description
+
+
+def graphql_response(data):
+    return {"success": True, "result": {"data": data}}
+
+
+def variant_response(total_count=1, nodes=None):
+    if nodes is None:
+        nodes = [{"id": 79, "name": "G12D", "link": "/variants/79", "variantAliases": ["GLY12ASP"]}]
+    return graphql_response(
+        {
+            "gene": {
+                "id": 30,
+                "name": "KRAS",
+                "entrezId": 3845,
+                "link": "/features/30",
+                "variants": {"totalCount": total_count, "nodes": nodes},
+            }
+        }
+    )
+
+
+def evidence_item(item_id=1300, rating=4):
+    return {
+        "id": item_id,
+        "name": f"EID{item_id}",
+        "link": f"/evidence/{item_id}",
+        "status": "ACCEPTED",
+        "description": "Curated variant evidence.",
+        "evidenceType": "PROGNOSTIC",
+        "evidenceLevel": "B",
+        "evidenceRating": rating,
+        "evidenceDirection": "SUPPORTS",
+        "significance": "POOR_OUTCOME",
+        "variantOrigin": "SOMATIC",
+        "disease": {"id": 556, "doid": "1793", "name": "Pancreatic Cancer", "displayName": "Pancreatic Cancer"},
+        "therapies": [],
+        "source": {
+            "sourceType": "PUBMED",
+            "citationId": "27010960",
+            "pmcId": "PMC4822095",
+            "title": "KRAS G12D Mutation Subtype Is A Prognostic Factor",
+        },
+    }
+
+
+def evidence_response(total_count=1, nodes=None):
+    if nodes is None:
+        nodes = [evidence_item()]
+    return graphql_response({"evidenceItems": {"totalCount": total_count, "nodes": nodes}})
+
+
+class CivicQueryTest(unittest.TestCase):
+    @mock.patch("biomni.tool.database._query_rest_api")
+    def test_returns_normalized_source_linked_evidence(self, request):
+        request.side_effect = [variant_response(), evidence_response()]
+
+        result = query_civic(
+            " kras ",
+            "KRAS p.G12D",
+            disease=" pancreatic ",
+            evidence_type="prognostic",
+            max_results=2,
+        )
+
+        self.assertEqual(result["query"]["gene"], "KRAS")
+        self.assertEqual(result["query"]["variant"], "G12D")
+        self.assertEqual(result["query"]["disease"], "pancreatic")
+        self.assertEqual(result["query"]["evidence_type"], "PROGNOSTIC")
+        self.assertEqual(result["query"]["evidence_status"], "ACCEPTED")
+        self.assertEqual(result["gene"]["url"], "https://civicdb.org/features/30")
+        self.assertEqual(result["matched_variants"][0]["url"], "https://civicdb.org/variants/79")
+        self.assertEqual(result["returned_evidence"], 1)
+        item = result["evidence_items"][0]
+        self.assertEqual(item["url"], "https://civicdb.org/evidence/1300")
+        self.assertEqual(item["variant"]["name"], "G12D")
+        self.assertEqual(item["source"]["pubmed_url"], "https://pubmed.ncbi.nlm.nih.gov/27010960/")
+        self.assertEqual(item["source"]["pmc_url"], "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4822095/")
+        self.assertIn("not clinical recommendations", result["notes"][1])
+
+        variant_call, evidence_call = request.call_args_list
+        self.assertEqual(
+            variant_call.kwargs["json_data"]["variables"],
+            {"gene": "KRAS", "variant": "G12D", "first": 5},
+        )
+        self.assertEqual(
+            evidence_call.kwargs["json_data"]["variables"],
+            {
+                "variantId": 79,
+                "disease": "pancreatic",
+                "evidenceType": "PROGNOSTIC",
+                "status": "ACCEPTED",
+                "first": 2,
+            },
+        )
+
+    @mock.patch("biomni.tool.database._query_rest_api")
+    def test_caps_alias_matches_and_total_evidence(self, request):
+        nodes = [
+            {"id": 148, "name": "G12A", "link": "/variants/148", "variantAliases": ["RS121913529"]},
+            {"id": 79, "name": "G12D", "link": "/variants/79", "variantAliases": ["RS121913529"]},
+        ]
+        request.side_effect = [
+            variant_response(total_count=3, nodes=nodes),
+            evidence_response(total_count=4, nodes=[evidence_item(1)]),
+            evidence_response(total_count=2, nodes=[evidence_item(2)]),
+        ]
+
+        result = query_civic("KRAS", "RS121913529", max_results=2, max_variants=2)
+
+        self.assertEqual(result["total_matching_variants"], 3)
+        self.assertEqual(result["total_evidence_for_returned_variants"], 6)
+        self.assertEqual(result["returned_evidence"], 2)
+        self.assertEqual([item["variant"]["name"] for item in result["evidence_items"]], ["G12A", "G12D"])
+        self.assertTrue(any("only the first 2" in note for note in result["notes"]))
+        self.assertTrue(any("max_results returned 2" in note for note in result["notes"]))
+
+    @mock.patch("biomni.tool.database._query_rest_api")
+    def test_missing_gene_and_variant_return_structured_empty_results(self, request):
+        request.side_effect = [
+            graphql_response({"gene": None}),
+            variant_response(total_count=0, nodes=[]),
+        ]
+
+        missing_gene = query_civic("NOTAGENE", "V1")
+        missing_variant = query_civic("KRAS", "NOTAVARIANT")
+
+        self.assertIn("was not found", missing_gene["error"])
+        self.assertEqual(missing_gene["evidence_items"], [])
+        self.assertEqual(missing_variant["total_matching_variants"], 0)
+        self.assertEqual(missing_variant["returned_evidence"], 0)
+        self.assertIn("No CIViC variant", missing_variant["note"])
+
+    @mock.patch("biomni.tool.database._query_rest_api")
+    def test_surfaces_graphql_and_transport_errors(self, request):
+        request.side_effect = [
+            {"success": True, "result": {"errors": [{"message": "invalid query"}]}},
+            {"success": False, "error": "API error: offline"},
+        ]
+
+        graphql_error = query_civic("KRAS", "G12D")
+        transport_error = query_civic("KRAS", "G12D")
+
+        self.assertEqual(graphql_error["error"], "CIViC GraphQL error: invalid query")
+        self.assertEqual(transport_error["error"], "API error: offline")
+
+    @mock.patch("biomni.tool.database._query_rest_api")
+    def test_nonaccepted_status_is_explicitly_warned(self, request):
+        submitted = evidence_item()
+        submitted["status"] = "SUBMITTED"
+        request.side_effect = [variant_response(), evidence_response(nodes=[submitted])]
+
+        result = query_civic("KRAS", "G12D", evidence_status="submitted")
+
+        self.assertEqual(result["query"]["evidence_status"], "SUBMITTED")
+        self.assertTrue(any("unreviewed or rejected" in note for note in result["notes"]))
+        evidence_payload = request.call_args_list[1].kwargs["json_data"]
+        self.assertNotIn("disease", evidence_payload["variables"])
+        self.assertNotIn("evidenceType", evidence_payload["variables"])
+        self.assertNotIn("diseaseName: $disease", evidence_payload["query"])
+        self.assertNotIn("evidenceType: $evidenceType", evidence_payload["query"])
+
+    @mock.patch("biomni.tool.database._query_rest_api")
+    def test_validates_inputs_before_network_calls(self, request):
+        cases = [
+            (("", "G12D"), {}, "gene"),
+            (("KRAS", ""), {}, "variant"),
+            (("KRAS", "G12D"), {"disease": ""}, "disease"),
+            (("KRAS", "G12D"), {"evidence_type": "unknown"}, "evidence_type"),
+            (("KRAS", "G12D"), {"evidence_status": "pending"}, "evidence_status"),
+            (("KRAS", "G12D"), {"max_results": 0}, "max_results"),
+            (("KRAS", "G12D"), {"max_results": True}, "max_results"),
+            (("KRAS", "G12D"), {"max_variants": 21}, "max_variants"),
+        ]
+        for args, kwargs, expected in cases:
+            with self.subTest(args=args, kwargs=kwargs):
+                self.assertIn(expected, query_civic(*args, **kwargs)["error"])
+        request.assert_not_called()
+
+    def test_tool_description_matches_signature(self):
+        tool = next(item for item in description if item["name"] == "query_civic")
+        schema_required = {item["name"] for item in tool["required_parameters"]}
+        schema_defaults = {item["name"]: item["default"] for item in tool["optional_parameters"]}
+        signature = inspect.signature(query_civic)
+        function_required = {
+            name for name, parameter in signature.parameters.items() if parameter.default is inspect.Parameter.empty
+        }
+        function_defaults = {
+            name: parameter.default
+            for name, parameter in signature.parameters.items()
+            if parameter.default is not inspect.Parameter.empty
+        }
+
+        self.assertEqual(schema_required, function_required)
+        self.assertEqual(schema_defaults, function_defaults)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `query_civic`, an agent-exposed database tool for retrieving curated cancer-variant evidence by gene symbol and variant name or alias
- support optional disease, evidence-type, and curation-status filters without using an LLM to construct GraphQL
- default to reviewed `ACCEPTED` records and return CIViC status, evidence level, rating, direction, significance, disease, therapies, and source-linked PubMed/PMC citations
- normalize inputs such as `KRAS p.G12D`, bound multi-variant alias matches and result counts, surface GraphQL errors that arrive with HTTP 200, and warn explicitly when non-accepted evidence is requested

This addresses the CIViC integration suggested in #22. It complements ClinVar and cBioPortal with curated functional and clinical interpretation evidence rather than replacing either source or inventing a new score.

CIViC documents that the same public GraphQL API used by its frontend is available to external users, and that its content is CC0: [official CIViC repository](https://github.com/griffithlab/civic-v2) and [generated API documentation](https://griffithlab.github.io/civic-v2/).

## Verification

- `uv run --python 3.11 --with biopython --with pandas --with requests --with tqdm python -m unittest tests/test_civic_query.py -v` — 7 tests pass
- `uvx pre-commit run --all-files` — all hooks pass
- live public-API smoke test: `KRAS p.G12D`, disease `pancreatic`, status `ACCEPTED` returned 3 source-linked records on 2026-08-18
- live filtered smoke test: `TP53 p.R175H`, type `FUNCTIONAL`, status `ACCEPTED` returned 1 functional record on 2026-08-18
- real Biomni `api_schema_to_langchain_tool` invocation returned 23 accepted KRAS G12D evidence records with PubMed links

The committed tests mock transport deterministically and cover input normalization, optional GraphQL argument omission, alias fan-out, global result caps, source links, empty results, transport/GraphQL errors, non-accepted warnings, validation, and schema/signature parity. Live counts are observations, not stable test assertions.

## Agent test prompt

> Retrieve accepted CIViC evidence for the KRAS G12D variant in pancreatic cancer. Summarize the evidence type, level, rating, direction, significance, disease, therapies, and linked literature source for each returned record, and clearly state that these are evidence records rather than clinical recommendations.

## AI assistance disclosure

This contribution was implemented and tested with assistance from OpenAI Codex. I reviewed the final diff, checked it against the live CIViC GraphQL schema and official repository documentation, and ran the tests and live queries described above.