### PR TITLE
Fix schema prompt rendering with literal JSON examples

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -63,7 +63,11 @@ def _query_llm_for_api(prompt, schema, system_template):
         # Format the system prompt with schema if provided
         if schema is not None:
             schema_json = json.dumps(schema, indent=2)
-            system_prompt = system_template.format(schema=schema_json)
+            escaped_left_brace = "\0BIOMNI_ESCAPED_LEFT_BRACE\0"
+            escaped_right_brace = "\0BIOMNI_ESCAPED_RIGHT_BRACE\0"
+            system_prompt = system_template.replace("{{", escaped_left_brace).replace("}}", escaped_right_brace)
+            system_prompt = system_prompt.replace("{schema}", schema_json)
+            system_prompt = system_prompt.replace(escaped_left_brace, "{").replace(escaped_right_brace, "}")
         else:
             system_prompt = system_template
 

--- a/tests/test_database_schema_template.py
+++ b/tests/test_database_schema_template.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest import mock
+
+from biomni.tool.database import _query_llm_for_api, query_geo
+
+
+class FakeResponse:
+    content = '{"search_term": "BRCA1[gene]"}'
+
+
+class FakeLLM:
+    def __init__(self):
+        self.messages = None
+
+    def invoke(self, messages):
+        self.messages = messages
+        return FakeResponse()
+
+
+class DatabaseSchemaTemplateTest(unittest.TestCase):
+    @mock.patch("biomni.tool.database._query_ncbi_database")
+    @mock.patch("biomni.tool.database.get_llm")
+    def test_query_geo_template_with_json_examples_is_rendered(self, get_llm, query_ncbi):
+        llm = FakeLLM()
+        get_llm.return_value = llm
+        query_ncbi.return_value = {"database": "gds", "total_results": 0}
+
+        result = query_geo(prompt="Find breast cancer RNA-seq datasets")
+
+        self.assertEqual(result, {"database": "gds", "total_results": 0})
+        query_ncbi.assert_called_once_with(
+            database="gds",
+            search_term="BRCA1[gene]",
+            max_results=3,
+        )
+        system_prompt = llm.messages[0].content
+        self.assertIn('For "RNA-seq data in breast cancer": {"search_term":', system_prompt)
+        self.assertNotIn("{schema}", system_prompt)
+
+    @mock.patch("biomni.tool.database.get_llm")
+    def test_schema_substitution_preserves_literal_json_examples(self, get_llm):
+        llm = FakeLLM()
+        get_llm.return_value = llm
+        template = """
+        DATABASE SCHEMA:
+        {schema}
+
+        Return JSON like {"search_term": "BRCA1[gene]"}.
+        Existing escaped example: {{"full_url": "https://example.test"}}.
+        The response must include {search_term} as a literal reminder.
+        """
+
+        result = _query_llm_for_api(
+            prompt="Find BRCA1 records",
+            schema={"fields": ["gene", "clinical_significance"]},
+            system_template=template,
+        )
+
+        self.assertTrue(result["success"])
+        system_prompt = llm.messages[0].content
+        self.assertIn('"fields": [', system_prompt)
+        self.assertIn('Return JSON like {"search_term": "BRCA1[gene]"}.', system_prompt)
+        self.assertIn('Existing escaped example: {"full_url": "https://example.test"}.', system_prompt)
+        self.assertNotIn('{{"full_url"', system_prompt)
+        self.assertIn("{search_term} as a literal reminder", system_prompt)
+
+    @mock.patch("biomni.tool.database.get_llm")
+    def test_template_without_schema_placeholder_does_not_raise(self, get_llm):
+        llm = FakeLLM()
+        get_llm.return_value = llm
+        template = 'Return only {"search_term": "value"}.'
+
+        result = _query_llm_for_api(
+            prompt="Find a record",
+            schema={"field": "value"},
+            system_template=template,
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(llm.messages[0].content, template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace broad `str.format()` processing with targeted `{schema}` substitution in the shared database API prompt helper
- preserve literal JSON examples and other brace-delimited reminders instead of interpreting them as format fields
- retain the existing behavior for intentionally escaped `{{...}}` examples by restoring them to single braces after substitution
- add a direct `query_geo` regression plus focused helper tests

Fixes #170.

## Problem

`_query_llm_for_api` currently calls `system_template.format(schema=schema_json)`. Several database prompts, including `query_geo`, contain ordinary JSON examples such as `{"search_term": ...}`. Python interprets those braces as additional format fields and the helper returns an error such as `KeyError: "search_term"` before the model is called.

A plain `replace()` avoids that exception but would leave older escaped examples such as `{{"full_url": ...}}` doubled in the model prompt. This change temporarily protects those existing escapes, substitutes only the schema placeholder, and then restores the intended single braces.

## Verification

- `uv run --python 3.11 --with biopython --with pandas --with requests --with tqdm python -m unittest tests/test_database_schema_template.py -v` — 3 tests pass
- `uvx pre-commit run --all-files` — all hooks pass
- the regression executes the real `query_geo` prompt path with its unescaped JSON examples, verifies schema insertion, and confirms the structured NCBI query is reached
- focused cases cover mixed unescaped JSON, a literal `{search_term}` reminder, legacy `{{...}}` escaping, and a template without a schema placeholder

## AI assistance disclosure

This contribution was implemented and tested with assistance from OpenAI Codex. I reviewed the final diff and ran the tests and repository checks above.