### PR TITLE
Add GlyGen glycosylation evidence query tool

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pickle
+import re
 import time
 from typing import Any
 
@@ -539,6 +540,336 @@ def query_uniprot(
     api_result = _query_rest_api(endpoint=endpoint, method="GET", description=description)
 
     return api_result
+
+
+def _format_glygen_evidence(evidence, limit):
+    if limit == 0:
+        return []
+    formatted = []
+    seen = set()
+    for item in evidence if isinstance(evidence, list) else []:
+        if not isinstance(item, dict):
+            continue
+        record = {
+            "database": item.get("database") or item.get("type"),
+            "id": item.get("id"),
+            "url": item.get("url"),
+        }
+        if not any(record.values()):
+            continue
+        key = tuple(record.values())
+        if key in seen:
+            continue
+        seen.add(key)
+        formatted.append(record)
+        if len(formatted) == limit:
+            break
+    return formatted
+
+
+def _query_glygen_api(record_type, identifier, timeout):
+    endpoint = f"https://api.glygen.org/{record_type}/detail/{identifier}/"
+    try:
+        response = requests.post(
+            endpoint,
+            json={},
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        result = response.json()
+    except requests.RequestException as error:
+        return None, {"error": f"GlyGen API request failed: {error}", "endpoint": endpoint}
+    except ValueError as error:
+        return None, {"error": f"GlyGen returned invalid JSON: {error}", "endpoint": endpoint}
+
+    if not isinstance(result, dict):
+        return None, {"error": "GlyGen returned an unexpected response", "endpoint": endpoint}
+    if result.get("error"):
+        return None, {"error": f"GlyGen API error: {result['error']}", "endpoint": endpoint}
+    return result, None
+
+
+def query_glygen(
+    identifier,
+    record_type="auto",
+    glycosylation_type=None,
+    max_results=10,
+    max_evidence=3,
+    include_sequence=False,
+    timeout=30,
+):
+    """Retrieve source-linked glycoprotein or glycan records from GlyGen.
+
+    Parameters
+    ----------
+    identifier (str): UniProt accession for a protein record or GlyTouCan accession for a glycan record.
+    record_type (str): ``auto``, ``protein``/``uniprot``, or ``glycan``/``glytoucan``.
+    glycosylation_type (str, optional): Protein-site filter such as ``N-linked`` or ``O-linked``.
+    max_results (int): Maximum site associations or related records returned per section (1-50).
+    max_evidence (int): Maximum source links retained for each association (0-10).
+    include_sequence (bool): Include the full protein sequence instead of only its length.
+    timeout (int or float): HTTP timeout in seconds (1-120).
+
+    Returns
+    -------
+    dict: A normalized GlyGen record with evidence links and truncation metadata.
+
+    """
+    if not isinstance(identifier, str) or not identifier.strip():
+        return {"error": "identifier must be a non-empty string"}
+    if not isinstance(record_type, str):
+        return {"error": "record_type must be 'auto', 'protein', or 'glycan'"}
+
+    type_aliases = {
+        "protein": "protein",
+        "uniprot": "protein",
+        "glycan": "glycan",
+        "glytoucan": "glycan",
+    }
+    normalized_id = identifier.strip().upper()
+    requested_type = record_type.strip().lower()
+    if requested_type == "auto":
+        normalized_type = "glycan" if re.fullmatch(r"G[A-Z0-9]{7}", normalized_id) else "protein"
+    else:
+        normalized_type = type_aliases.get(requested_type)
+    if normalized_type is None:
+        return {"error": "record_type must be 'auto', 'protein'/'uniprot', or 'glycan'/'glytoucan'"}
+
+    if normalized_type == "protein" and not re.fullmatch(r"[A-Z0-9]{6,10}(?:-[0-9]+)?", normalized_id):
+        return {"error": "identifier must be a valid-looking UniProt accession"}
+    if normalized_type == "glycan" and not re.fullmatch(r"G[A-Z0-9]{7}", normalized_id):
+        return {"error": "identifier must be an 8-character GlyTouCan accession beginning with G"}
+    if isinstance(max_results, bool) or not isinstance(max_results, int) or not 1 <= max_results <= 50:
+        return {"error": "max_results must be an integer from 1 to 50"}
+    if isinstance(max_evidence, bool) or not isinstance(max_evidence, int) or not 0 <= max_evidence <= 10:
+        return {"error": "max_evidence must be an integer from 0 to 10"}
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or not 1 <= timeout <= 120:
+        return {"error": "timeout must be a number from 1 to 120 seconds"}
+    if not isinstance(include_sequence, bool):
+        return {"error": "include_sequence must be a boolean"}
+
+    normalized_glycosylation_type = None
+    if glycosylation_type is not None:
+        if normalized_type != "protein":
+            return {"error": "glycosylation_type can only be used with protein records"}
+        if not isinstance(glycosylation_type, str) or not glycosylation_type.strip():
+            return {"error": "glycosylation_type must be a non-empty string when provided"}
+        normalized_glycosylation_type = glycosylation_type.strip()
+
+    raw, error = _query_glygen_api(normalized_type, normalized_id, timeout)
+    if error:
+        return error
+
+    source = {
+        "name": "GlyGen",
+        "api_url": f"https://api.glygen.org/{normalized_type}/detail/{normalized_id}/",
+        "record_url": f"https://glygen.org/{normalized_type}/{normalized_id}",
+    }
+    query = {
+        "identifier": normalized_id,
+        "record_type": normalized_type,
+        "glycosylation_type": normalized_glycosylation_type,
+    }
+
+    if normalized_type == "protein":
+        protein_names = raw.get("protein_names", [])
+        recommended_name = next(
+            (
+                item.get("name")
+                for item in protein_names
+                if isinstance(item, dict) and item.get("type") == "recommended"
+            ),
+            None,
+        )
+        if recommended_name is None:
+            recommended_name = next(
+                (item.get("name") for item in protein_names if isinstance(item, dict) and item.get("name")),
+                None,
+            )
+
+        gene_names = []
+        for item in raw.get("gene_names", []):
+            name = item.get("name") if isinstance(item, dict) else None
+            if name and name not in gene_names:
+                gene_names.append(name)
+
+        species = raw.get("species", [])
+        species_record = species[0] if species and isinstance(species[0], dict) else {}
+        sequence_record = raw.get("sequence", {})
+        if not isinstance(sequence_record, dict):
+            sequence_record = {}
+        sequence = sequence_record.get("sequence", "")
+
+        associations = [item for item in raw.get("glycosylation", []) if isinstance(item, dict)]
+        if normalized_glycosylation_type:
+            requested_glycosylation_type = normalized_glycosylation_type.casefold()
+            associations = [
+                item for item in associations if str(item.get("type", "")).casefold() == requested_glycosylation_type
+            ]
+
+        returned_sites = []
+        for item in associations[:max_results]:
+            evidence = item.get("evidence", [])
+            glytoucan_ac = item.get("glytoucan_ac")
+            returned_sites.append(
+                {
+                    "position": item.get("start_pos"),
+                    "end_position": item.get("end_pos"),
+                    "residue": item.get("residue") or item.get("start_aa"),
+                    "site_label": item.get("site_lbl"),
+                    "site_sequence": item.get("site_seq"),
+                    "type": item.get("type"),
+                    "subtype": item.get("subtype"),
+                    "site_category": item.get("site_category"),
+                    "glytoucan_ac": glytoucan_ac,
+                    "glycan_url": f"https://glygen.org/glycan/{glytoucan_ac}" if glytoucan_ac else None,
+                    "comment": item.get("comment"),
+                    "evidence_count": len(evidence) if isinstance(evidence, list) else 0,
+                    "evidence": _format_glygen_evidence(evidence, max_evidence),
+                }
+            )
+
+        result = {
+            "success": True,
+            "source": source,
+            "query": query,
+            "protein": {
+                "requested_uniprot_accession": normalized_id,
+                "canonical_uniprot_accession": raw.get("uniprot", {}).get("uniprot_canonical_ac")
+                if isinstance(raw.get("uniprot"), dict)
+                else None,
+                "recommended_name": recommended_name,
+                "gene_names": gene_names[:10],
+                "species": {"name": species_record.get("name"), "taxid": species_record.get("taxid")},
+                "mass": raw.get("mass"),
+                "sequence_length": sequence_record.get("length") or len(sequence),
+            },
+            "matching_glycosylation_associations": len(associations),
+            "unique_matching_sites": len(
+                {(item.get("type"), item.get("start_pos"), item.get("end_pos")) for item in associations}
+            ),
+            "returned_associations": len(returned_sites),
+            "glycosylation_sites": returned_sites,
+            "notes": [
+                "GlyGen integrates records from multiple databases; follow each evidence link for provenance.",
+                "Reported site associations are evidence records, not predictions or treatment recommendations.",
+            ],
+        }
+        if include_sequence:
+            result["protein"]["sequence"] = sequence
+        if len(associations) > max_results:
+            result["notes"].append(
+                f"Returned the first {max_results} of {len(associations)} matching glycosylation associations."
+            )
+        return result
+
+    def related_records(items, fields):
+        records = []
+        for item in items[:max_results] if isinstance(items, list) else []:
+            if not isinstance(item, dict):
+                continue
+            record = {output_name: item.get(source_name) for output_name, source_name in fields.items()}
+            evidence = item.get("evidence", [])
+            record["evidence_count"] = len(evidence) if isinstance(evidence, list) else 0
+            record["evidence"] = _format_glygen_evidence(evidence, max_evidence)
+            records.append(record)
+        return records
+
+    species = raw.get("species", [])
+    glycoproteins = raw.get("glycoprotein", [])
+    enzymes = raw.get("enzyme", [])
+    publications = raw.get("publication", [])
+    result = {
+        "success": True,
+        "source": source,
+        "query": query,
+        "glycan": {
+            "glytoucan_ac": raw.get("glytoucan", {}).get("glytoucan_ac")
+            if isinstance(raw.get("glytoucan"), dict)
+            else normalized_id,
+            "glytoucan_url": raw.get("glytoucan", {}).get("glytoucan_url")
+            if isinstance(raw.get("glytoucan"), dict)
+            else None,
+            "mass": raw.get("mass"),
+            "number_monosaccharides": raw.get("number_monosaccharides"),
+            "glycan_type": raw.get("glycan_type"),
+            "iupac": raw.get("iupac"),
+            "iupac_condensed": raw.get("iupac_condensed"),
+            "wurcs": raw.get("wurcs"),
+            "composition": raw.get("composition", []),
+            "classification": [
+                {
+                    "type": item.get("type", {}).get("name") if isinstance(item.get("type"), dict) else None,
+                    "subtype": item.get("subtype", {}).get("name") if isinstance(item.get("subtype"), dict) else None,
+                }
+                for item in raw.get("classification", [])
+                if isinstance(item, dict)
+            ],
+        },
+        "counts": {
+            "species": len(species) if isinstance(species, list) else 0,
+            "glycoproteins": len(glycoproteins) if isinstance(glycoproteins, list) else 0,
+            "enzymes": len(enzymes) if isinstance(enzymes, list) else 0,
+            "publications": len(publications) if isinstance(publications, list) else 0,
+        },
+        "species": related_records(
+            species,
+            {"name": "name", "common_name": "common_name", "taxid": "taxid"},
+        ),
+        "glycoproteins": related_records(
+            glycoproteins,
+            {
+                "uniprot_accession": "uniprot_canonical_ac",
+                "protein_name": "protein_name",
+                "gene_name": "gene_name",
+                "position": "start_pos",
+                "residue": "residue",
+                "taxid": "tax_id",
+                "species": "tax_name",
+            },
+        ),
+        "enzymes": related_records(
+            enzymes,
+            {
+                "uniprot_accession": "uniprot_canonical_ac",
+                "protein_name": "protein_name",
+                "gene_name": "gene",
+                "taxid": "tax_id",
+                "species": "tax_name",
+            },
+        ),
+        "publications": [
+            {
+                "title": item.get("title"),
+                "journal": item.get("journal"),
+                "date": item.get("date"),
+                "authors": item.get("authors"),
+                "references": _format_glygen_evidence(item.get("reference", []), max_evidence),
+            }
+            for item in publications[:max_results]
+            if isinstance(item, dict)
+        ],
+        "notes": [
+            "GlyGen integrates records from multiple databases; follow each evidence link for provenance.",
+            "Associations are source records, not predictions or treatment recommendations.",
+        ],
+    }
+    truncated_sections = [
+        name
+        for name, items in (
+            ("species", species),
+            ("glycoproteins", glycoproteins),
+            ("enzymes", enzymes),
+            ("publications", publications),
+        )
+        if isinstance(items, list) and len(items) > max_results
+    ]
+    if truncated_sections:
+        result["notes"].append(
+            f"Returned at most {max_results} records in truncated sections: {', '.join(truncated_sections)}."
+        )
+    return result
 
 
 def query_alphafold(

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -21,6 +21,56 @@ description = [
         ],
     },
     {
+        "description": "Retrieve source-linked protein glycosylation sites or glycan structures and associations from the public GlyGen API.",
+        "name": "query_glygen",
+        "optional_parameters": [
+            {
+                "name": "record_type",
+                "type": "str",
+                "description": "Record type: 'auto', 'protein'/'uniprot', or 'glycan'/'glytoucan'",
+                "default": "auto",
+            },
+            {
+                "name": "glycosylation_type",
+                "type": "str",
+                "description": "Optional protein-site type filter, such as 'N-linked' or 'O-linked'",
+                "default": None,
+            },
+            {
+                "name": "max_results",
+                "type": "int",
+                "description": "Maximum site associations or related records per section (1-50)",
+                "default": 10,
+            },
+            {
+                "name": "max_evidence",
+                "type": "int",
+                "description": "Maximum source links per association (0-10)",
+                "default": 3,
+            },
+            {
+                "name": "include_sequence",
+                "type": "bool",
+                "description": "Include the full protein sequence",
+                "default": False,
+            },
+            {
+                "name": "timeout",
+                "type": "int|float",
+                "description": "GlyGen API timeout in seconds (1-120)",
+                "default": 30,
+            },
+        ],
+        "required_parameters": [
+            {
+                "name": "identifier",
+                "type": "str",
+                "description": "UniProt accession (protein) or GlyTouCan accession (glycan)",
+                "default": None,
+            }
+        ],
+    },
+    {
         "description": "Query the AlphaFold Database API for protein structure predictions or metadata; optionally download structures.",
         "name": "query_alphafold",
         "optional_parameters": [

--- a/tests/test_glygen_query.py
+++ b/tests/test_glygen_query.py
@@ -1,0 +1,221 @@
+import inspect
+import unittest
+from unittest import mock
+
+import requests
+from biomni.tool.database import query_glygen
+from biomni.tool.tool_description.database import description
+
+
+def response_with(payload):
+    response = mock.MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def protein_payload():
+    return {
+        "uniprot": {"uniprot_canonical_ac": "P00533-1"},
+        "protein_names": [
+            {"name": "EGFR synonym", "type": "synonym"},
+            {"name": "Epidermal growth factor receptor", "type": "recommended"},
+        ],
+        "gene_names": [{"name": "EGFR"}, {"name": "ERBB1"}, {"name": "EGFR"}],
+        "species": [{"name": "Homo sapiens", "taxid": 9606}],
+        "mass": 134277,
+        "sequence": {"sequence": "MNST", "length": 4},
+        "glycosylation": [
+            {
+                "start_pos": 56,
+                "end_pos": 56,
+                "residue": "Asn",
+                "site_lbl": "Asn56",
+                "site_seq": "VCQGTSNKLTQ",
+                "type": "N-linked",
+                "subtype": "other",
+                "site_category": "reported_with_glycan",
+                "glytoucan_ac": "G11111AA",
+                "evidence": [
+                    {"database": "PubMed", "id": "1", "url": "https://pubmed.example/1"},
+                    {"database": "PubMed", "id": "2", "url": "https://pubmed.example/2"},
+                ],
+            },
+            {
+                "start_pos": 128,
+                "end_pos": 128,
+                "residue": "Asn",
+                "type": "N-linked",
+                "site_category": "reported",
+                "evidence": [],
+            },
+            {"start_pos": 1096, "end_pos": 1096, "residue": "Ser", "type": "O-linked"},
+        ],
+    }
+
+
+class GlyGenQueryTest(unittest.TestCase):
+    @mock.patch("biomni.tool.database.requests.post")
+    def test_protein_record_filters_sites_and_preserves_sources(self, post):
+        post.return_value = response_with(protein_payload())
+
+        result = query_glygen(
+            " p00533 ",
+            record_type="uniprot",
+            glycosylation_type="n-LINKED",
+            max_results=1,
+            max_evidence=1,
+            include_sequence=True,
+            timeout=12,
+        )
+
+        post.assert_called_once_with(
+            "https://api.glygen.org/protein/detail/P00533/",
+            json={},
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            timeout=12,
+        )
+        self.assertTrue(result["success"])
+        self.assertEqual(result["protein"]["canonical_uniprot_accession"], "P00533-1")
+        self.assertEqual(result["protein"]["recommended_name"], "Epidermal growth factor receptor")
+        self.assertEqual(result["protein"]["gene_names"], ["EGFR", "ERBB1"])
+        self.assertEqual(result["protein"]["sequence"], "MNST")
+        self.assertEqual(result["matching_glycosylation_associations"], 2)
+        self.assertEqual(result["unique_matching_sites"], 2)
+        self.assertEqual(result["returned_associations"], 1)
+        site = result["glycosylation_sites"][0]
+        self.assertEqual(site["glycan_url"], "https://glygen.org/glycan/G11111AA")
+        self.assertEqual(site["evidence_count"], 2)
+        self.assertEqual(len(site["evidence"]), 1)
+        self.assertTrue(any("first 1 of 2" in note for note in result["notes"]))
+
+    @mock.patch("biomni.tool.database.requests.post")
+    def test_glycan_record_normalizes_associations_and_reports_truncation(self, post):
+        post.return_value = response_with(
+            {
+                "glytoucan": {
+                    "glytoucan_ac": "G17689DH",
+                    "glytoucan_url": "https://glytoucan.org/Structures/Glycans/G17689DH",
+                },
+                "mass": 2368.84,
+                "number_monosaccharides": 12,
+                "glycan_type": "Saccharide",
+                "iupac": "full IUPAC",
+                "iupac_condensed": "condensed IUPAC",
+                "wurcs": "WURCS=2.0/example",
+                "composition": [{"name": "Hexose", "count": 5}],
+                "classification": [{"type": {"name": "N-linked"}, "subtype": {"name": "Complex"}}],
+                "species": [
+                    {
+                        "name": "Homo sapiens",
+                        "common_name": "Human",
+                        "taxid": 9606,
+                        "evidence": [{"database": "PubMed", "id": "10", "url": "https://example/10"}],
+                    },
+                    {"name": "Mus musculus", "taxid": 10090},
+                ],
+                "glycoprotein": [
+                    {
+                        "uniprot_canonical_ac": "P01588-1",
+                        "protein_name": "Erythropoietin",
+                        "gene_name": "EPO",
+                        "start_pos": 65,
+                        "residue": "asn",
+                        "tax_id": 9606,
+                        "tax_name": "Homo sapiens",
+                        "evidence": [],
+                    }
+                ],
+                "enzyme": [],
+                "publication": [
+                    {
+                        "title": "A glycan paper",
+                        "journal": "Glycobiology",
+                        "date": "2025",
+                        "authors": "A. Author",
+                        "reference": [
+                            {
+                                "type": "PubMed",
+                                "id": "123",
+                                "url": "https://glygen.org/publication/PubMed/123",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        result = query_glygen("g17689dh", max_results=1)
+
+        post.assert_called_once_with(
+            "https://api.glygen.org/glycan/detail/G17689DH/",
+            json={},
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            timeout=30,
+        )
+        self.assertEqual(result["glycan"]["classification"], [{"type": "N-linked", "subtype": "Complex"}])
+        self.assertEqual(result["counts"], {"species": 2, "glycoproteins": 1, "enzymes": 0, "publications": 1})
+        self.assertEqual(result["species"][0]["taxid"], 9606)
+        self.assertEqual(result["glycoproteins"][0]["gene_name"], "EPO")
+        self.assertEqual(result["publications"][0]["references"][0]["database"], "PubMed")
+        self.assertTrue(any("truncated sections: species" in note for note in result["notes"]))
+
+    @mock.patch("biomni.tool.database.requests.post")
+    def test_zero_evidence_limit_omits_source_links(self, post):
+        post.return_value = response_with(protein_payload())
+
+        result = query_glygen("P00533", max_evidence=0)
+
+        self.assertEqual(result["glycosylation_sites"][0]["evidence_count"], 2)
+        self.assertEqual(result["glycosylation_sites"][0]["evidence"], [])
+
+    @mock.patch("biomni.tool.database.requests.post")
+    def test_validates_inputs_before_network_calls(self, post):
+        cases = [
+            (("",), {}, "identifier"),
+            (("P00533",), {"record_type": "unknown"}, "record_type"),
+            (("../secret",), {}, "UniProt"),
+            (("P00533",), {"max_results": 0}, "max_results"),
+            (("P00533",), {"max_results": True}, "max_results"),
+            (("P00533",), {"max_evidence": 11}, "max_evidence"),
+            (("P00533",), {"timeout": 0}, "timeout"),
+            (("P00533",), {"include_sequence": "yes"}, "include_sequence"),
+            (("G17689DH",), {"record_type": "glycan", "glycosylation_type": "N-linked"}, "protein"),
+            (("not-a-glycan",), {"record_type": "glycan"}, "GlyTouCan"),
+        ]
+        for args, kwargs, expected in cases:
+            with self.subTest(args=args, kwargs=kwargs):
+                self.assertIn(expected, query_glygen(*args, **kwargs)["error"])
+        post.assert_not_called()
+
+    @mock.patch("biomni.tool.database.requests.post")
+    def test_surfaces_transport_and_response_errors(self, post):
+        post.side_effect = requests.Timeout("offline")
+        self.assertIn("request failed", query_glygen("P00533")["error"])
+
+        post.side_effect = None
+        post.return_value = response_with(["unexpected"])
+        self.assertIn("unexpected response", query_glygen("P00533")["error"])
+
+        post.return_value = response_with({"error": "record not found"})
+        self.assertEqual(query_glygen("P00533")["error"], "GlyGen API error: record not found")
+
+    def test_tool_description_matches_signature(self):
+        tool = next(item for item in description if item["name"] == "query_glygen")
+        schema_required = {item["name"] for item in tool["required_parameters"]}
+        schema_defaults = {item["name"]: item["default"] for item in tool["optional_parameters"]}
+        signature = inspect.signature(query_glygen)
+        function_required = {
+            name for name, parameter in signature.parameters.items() if parameter.default is inspect.Parameter.empty
+        }
+        function_defaults = {
+            name: parameter.default
+            for name, parameter in signature.parameters.items()
+            if parameter.default is not inspect.Parameter.empty
+        }
+
+        self.assertEqual(schema_required, function_required)
+        self.assertEqual(schema_defaults, function_defaults)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `query_glygen` as a structured database tool backed by GlyGen's public REST API
- retrieve UniProt protein records with normalized glycosylation-site/glycan associations and source links
- retrieve GlyTouCan glycan records with compositions, classifications, species, glycoproteins, enzymes, and publications
- automatically distinguish UniProt and GlyTouCan identifiers so both record types work through Biomni's current agent tool wrapper
- cap records and per-association evidence, validate identifiers before requests, expose timeouts, and label records as evidence rather than predictions

This extends the glycoengineering support requested in #198 with a directly queryable, source-linked data integration. It is distinct from `query_uniprot`: GlyGen aggregates glycosylation sites, glycan structures, enzymes, and evidence across glycoinformatics sources.

## Validation

- `python -m pytest -q tests/test_glygen_query.py` — 6 passed, including 10 validation subcases
- all configured pre-commit hooks pass on the three changed files
- live official API query for EGFR `P00533` returned 238 glycosylation associations; an O-linked filter returned 9 unique reported sites with GlyGen/PubMed/O-GlcNAc source links
- live GlyTouCan query for `G17689DH` returned its N-linked biantennary/complex/core-fucosylated classifications and counts for 4 species, 54 glycoproteins, 29 enzymes, and 53 publications
- real `api_schema_to_langchain_tool` invocations succeeded for both `P00533` and `G17689DH`

## Agent test prompt

> Use `query_glygen` to retrieve the EGFR protein record for UniProt P00533 and summarize three reported glycosylation associations with their evidence links. Then retrieve GlyTouCan G17689DH and summarize its classifications and two associated human glycoproteins. Treat the returned associations as source records, not predictions or clinical recommendations.

## AI assistance disclosure

I used OpenAI Codex to inspect Biomni and the official GlyGen API schema, implement the integration, draft tests and this description, and run the validation commands. I reviewed the implementation and verified the live API and agent-wrapper results above.
