### PR TITLE
Expose optional parameters in agent tool schemas

### DIFF
--- a/biomni/utils.py
+++ b/biomni/utils.py
@@ -1,6 +1,8 @@
 import ast
 import enum
+import functools
 import importlib
+import inspect
 import json
 import os
 import pickle
@@ -520,6 +522,7 @@ class CustomBaseModel(BaseModel):
 
 
 def safe_execute_decorator(func):
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
@@ -544,18 +547,34 @@ def api_schema_to_langchain_tool(api_schema, mode="generated_tool", module_name=
         "integer": int,
         "boolean": bool,
         "pandas": pd.DataFrame,  # Use the imported pandas.DataFrame directly
+        "pd.DataFrame": Any,
+        "numpy.ndarray": Any,
         "str": str,
         "int": int,
+        "float": float,
         "bool": bool,
+        "list": list,
+        "list[str]": list[str],
+        "tuple": tuple,
+        "tuple or None": tuple | None,
+        "Tuple[str, str]": tuple[str, str],
         "List[str]": list[str],
         "List[int]": list[int],
         "Dict": dict,
         "Any": Any,
+        "callable": Any,
+        "int|str": int | str,
+        "str or dict": str | dict,
+        "str|list[str]": str | list[str],
+        "list or numpy.ndarray": Any,
+        "Optional[List[Dict[str, str]]]": list[dict[str, str]] | None,
     }
 
     # Create the fields and annotations
+    required_parameters = api_schema["required_parameters"]
+    optional_parameters = api_schema.get("optional_parameters", [])
     annotations = {}
-    for param in api_schema["required_parameters"]:
+    for param in required_parameters + optional_parameters:
         param_type = param["type"]
         if param_type in type_mapping:
             annotations[param["name"]] = type_mapping[param_type]
@@ -567,7 +586,22 @@ def api_schema_to_langchain_tool(api_schema, mode="generated_tool", module_name=
                 # Default to Any for unknown types
                 annotations[param["name"]] = Any
 
-    fields = {param["name"]: Field(description=param["description"]) for param in api_schema["required_parameters"]}
+    fields = {param["name"]: Field(description=param["description"]) for param in required_parameters}
+    function_parameters = inspect.signature(api_function).parameters
+    fields.update(
+        {
+            param["name"]: Field(
+                default=(
+                    function_parameters[param["name"]].default
+                    if param["name"] in function_parameters
+                    and function_parameters[param["name"]].default is not inspect.Parameter.empty
+                    else param.get("default")
+                ),
+                description=param["description"],
+            )
+            for param in optional_parameters
+        }
+    )
 
     # Create the ApiInput class dynamically
     ApiInput = type("Input", (CustomBaseModel,), {"__annotations__": annotations, **fields})

--- a/tests/test_optional_tool_parameters.py
+++ b/tests/test_optional_tool_parameters.py
@@ -1,0 +1,93 @@
+import unittest
+
+from biomni.tool.tool_description.glycoengineering import description
+from biomni.utils import api_schema_to_langchain_tool
+from pydantic import ValidationError
+
+
+def append_to_labels(value, labels=None):
+    if labels is None:
+        labels = []
+    labels.append(value)
+    return labels
+
+
+class OptionalToolParametersTest(unittest.TestCase):
+    def test_existing_optional_parameter_is_visible_and_forwarded(self):
+        schema = next(item for item in description if item["name"] == "find_n_glycosylation_motifs")
+        tool = api_schema_to_langchain_tool(
+            schema,
+            mode="custom_tool",
+            module_name="biomni.tool.glycoengineering",
+        )
+
+        properties = tool.args_schema.model_json_schema()["properties"]
+        self.assertEqual(properties["allow_overlap"]["default"], False)
+        self.assertEqual(
+            properties["allow_overlap"]["description"],
+            "Allow overlapping motif detections",
+        )
+        self.assertNotIn("allow_overlap", tool.args_schema.model_json_schema()["required"])
+
+        default_result = tool.invoke({"sequence": "NNST"})
+        override_result = tool.invoke({"sequence": "NNST", "allow_overlap": True})
+
+        self.assertIn("Total sequons found: 1", default_result)
+        self.assertIn("Total sequons found: 2", override_result)
+        self.assertIn("- 2: NST", override_result)
+
+    def test_required_parameter_validation_is_unchanged(self):
+        schema = next(item for item in description if item["name"] == "find_n_glycosylation_motifs")
+        tool = api_schema_to_langchain_tool(
+            schema,
+            mode="custom_tool",
+            module_name="biomni.tool.glycoengineering",
+        )
+
+        with self.assertRaises(ValidationError):
+            tool.invoke({"allow_overlap": True})
+
+    def test_optional_list_values_are_forwarded_without_leaking_between_calls(self):
+        schema = {
+            "name": "append_to_labels",
+            "description": "Append one value to a caller-specific label list.",
+            "required_parameters": [
+                {
+                    "name": "value",
+                    "type": "str",
+                    "description": "Value to append",
+                    "default": None,
+                }
+            ],
+            "optional_parameters": [
+                {
+                    "name": "labels",
+                    "type": "List[str]",
+                    "description": "Initial labels",
+                    "default": None,
+                }
+            ],
+        }
+        tool = api_schema_to_langchain_tool(schema, mode="custom_tool", module_name=__name__)
+
+        self.assertEqual(tool.invoke({"value": "first"}), ["first"])
+        self.assertEqual(tool.invoke({"value": "second"}), ["second"])
+        self.assertEqual(tool.invoke({"value": "last", "labels": ["initial"]}), ["initial", "last"])
+
+    def test_function_signature_corrects_stale_description_defaults(self):
+        from biomni.tool.tool_description.bioengineering import description as bioengineering_description
+
+        schema = next(item for item in bioengineering_description if item["name"] == "simulate_whole_cell_ode_model")
+        tool = api_schema_to_langchain_tool(
+            schema,
+            mode="custom_tool",
+            module_name="biomni.tool.bioengineering",
+        )
+        properties = tool.args_schema.model_json_schema()["properties"]
+
+        self.assertEqual(properties["time_span"]["default"], [0, 100])
+        self.assertEqual(properties["method"]["default"], "LSODA")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- include `optional_parameters` in dynamically generated Pydantic/LangChain tool schemas
- preserve each optional parameter's description and use the underlying function signature as the authoritative default
- forward explicit agent overrides instead of silently dropping them
- retain required-parameter validation
- preserve wrapped function metadata/signatures with `functools.wraps`
- normalize the optional type spellings currently present in Biomni descriptions, while representing non-JSON-native callables/NumPy/DataFrames as `Any` so JSON schema generation remains valid

## Root cause

`api_schema_to_langchain_tool` previously constructed both `__annotations__` and Pydantic fields from `required_parameters` only. Pydantic ignored the extra optional inputs, so the generated tool schema hid them and the wrapped function received its defaults even when an agent supplied an override.

Using function defaults matters because a few current descriptions contain serialized/stale forms (for example `"(0, 100)"` and `"'LSODA'"`) while the actual function defaults are `(0, 100)` and `"LSODA"`.

## Validation

- `python -m pytest -q tests/test_optional_tool_parameters.py` — 4 passed
- existing `find_n_glycosylation_motifs("NNST", allow_overlap=True)` now returns both overlapping sites through the real LangChain wrapper; omission still returns the default single site
- missing required `sequence` still raises the existing structured validation error
- explicit list-valued optional inputs are forwarded and calls remain isolated
- actual function defaults correct the stale whole-cell ODE description defaults in generated JSON schema
- generated JSON schemas successfully for all 160 tools in the 12 subject modules importable in the focused environment, with zero errors
- five heavy optional modules were not runtime-imported because their ESM/torch/imaging/PDF dependencies were not installed; their optional type spellings are covered by the normalized mapping
- all configured pre-commit hooks pass on changed files

## AI assistance disclosure

I used OpenAI Codex to diagnose and reproduce the issue, implement the change, draft tests and this description, and run the validation. I reviewed the code and all reported outputs.

Closes #324
