### PR TITLE
Fix custom LLM env var name mismatch between docs and config.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
 AWS_REGION=us-east-1
 
 # Optional: Custom model serving configuration
-# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
-# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+# BIOMNI_CUSTOM_BASE_URL=http://localhost:8000/v1
+# BIOMNI_CUSTOM_API_KEY=your_custom_api_key_here
 
 # Optional: Biomni data path (defaults to ./data)
 # BIOMNI_DATA_PATH=/path/to/your/data

--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ GROQ_API_KEY=your_groq_api_key_here
 
 # Optional: Set the source of your LLM for example:
 #"OpenAI", "AzureOpenAI", "Anthropic", "Ollama", "Gemini", "Bedrock", "Groq", "Custom"
-LLM_SOURCE=your_LLM_source_here
+BIOMNI_SOURCE=your_LLM_source_here
 
 # Optional: AWS Bedrock Configuration (if using AWS Bedrock models)
 AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
 AWS_REGION=us-east-1
 
 # Optional: Custom model serving configuration
-# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
-# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+# BIOMNI_CUSTOM_BASE_URL=http://localhost:8000/v1
+# BIOMNI_CUSTOM_API_KEY=your_custom_api_key_here
 
 # Optional: Biomni data path (defaults to ./data)
 # BIOMNI_DATA_PATH=/path/to/your/data
@@ -121,7 +121,7 @@ export AWS_BEARER_TOKEN_BEDROCK="YOUR_BEDROCK_API_KEY" # optional for AWS Bedroc
 export AWS_REGION="us-east-1" # optional, defaults to us-east-1 for Bedrock
 export GEMINI_API_KEY="YOUR_GEMINI_API_KEY" #optional if you want to use a gemini model
 export GROQ_API_KEY="YOUR_GROQ_API_KEY" # Optional: set this to use models served by Groq
-export LLM_SOURCE="Groq" # Optional: set this to use models served by Groq
+export BIOMNI_SOURCE="Groq" # Optional: set this to use models served by Groq
 
 
 ```

--- a/biomni/config.py
+++ b/biomni/config.py
@@ -68,12 +68,12 @@ class BiomniConfig:
             self.commercial_mode = os.getenv("BIOMNI_COMMERCIAL_MODE").lower() == "true"
         if os.getenv("BIOMNI_TEMPERATURE"):
             self.temperature = float(os.getenv("BIOMNI_TEMPERATURE"))
-        if os.getenv("BIOMNI_CUSTOM_BASE_URL"):
-            self.base_url = os.getenv("BIOMNI_CUSTOM_BASE_URL")
-        if os.getenv("BIOMNI_CUSTOM_API_KEY"):
-            self.api_key = os.getenv("BIOMNI_CUSTOM_API_KEY")
-        if os.getenv("BIOMNI_SOURCE"):
-            self.source = os.getenv("BIOMNI_SOURCE")
+        if os.getenv("BIOMNI_CUSTOM_BASE_URL") or os.getenv("CUSTOM_MODEL_BASE_URL"):
+            self.base_url = os.getenv("BIOMNI_CUSTOM_BASE_URL") or os.getenv("CUSTOM_MODEL_BASE_URL")
+        if os.getenv("BIOMNI_CUSTOM_API_KEY") or os.getenv("CUSTOM_MODEL_API_KEY"):
+            self.api_key = os.getenv("BIOMNI_CUSTOM_API_KEY") or os.getenv("CUSTOM_MODEL_API_KEY")
+        if os.getenv("BIOMNI_SOURCE") or os.getenv("LLM_SOURCE"):
+            self.source = os.getenv("BIOMNI_SOURCE") or os.getenv("LLM_SOURCE")
 
         # Protocols.io access token (prefer specific env vars)
         env_token = os.getenv("PROTOCOLS_IO_ACCESS_TOKEN") or os.getenv("BIOMNI_PROTOCOLS_IO_ACCESS_TOKEN")


### PR DESCRIPTION
## Summary

The environment variable names documented in `.env.example` and the README (`CUSTOM_MODEL_BASE_URL`, `CUSTOM_MODEL_API_KEY`, `LLM_SOURCE`) do not match what `biomni/config.py` actually reads (`BIOMNI_CUSTOM_BASE_URL`, `BIOMNI_CUSTOM_API_KEY`, `BIOMNI_SOURCE`). Setting the documented variables has no effect, making custom-served LLM providers unusable.

Fixes #310.

## Changes

- `.env.example`: rename custom LLM vars to the names `config.py` reads
- `README.md`: update both the `.env` block and the bash export block
- `biomni/config.py`: accept both old and new names for backwards compatibility (new names take priority, old names still work)

## Verification

Tested `BiomniConfig` with three scenarios:
- Old names only -> correctly loaded
- Both names set -> new names take priority
- Neither set -> defaults preserved