### PR TITLE
docs: align custom LLM env var names with config.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
 AWS_REGION=us-east-1
 
-# Optional: Custom model serving configuration
-# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
-# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+# Optional: Custom model serving configuration (names must match biomni/config.py)
+# BIOMNI_SOURCE=Custom
+# BIOMNI_CUSTOM_BASE_URL=http://localhost:8000/v1
+# BIOMNI_CUSTOM_API_KEY=your_custom_api_key_here
 
 # Optional: Biomni data path (defaults to ./data)
 # BIOMNI_DATA_PATH=/path/to/your/data

--- a/README.md
+++ b/README.md
@@ -90,17 +90,17 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Optional: groq API Key (if using groq as model provider)
 GROQ_API_KEY=your_groq_api_key_here
 
-# Optional: Set the source of your LLM for example:
-#"OpenAI", "AzureOpenAI", "Anthropic", "Ollama", "Gemini", "Bedrock", "Groq", "Custom"
-LLM_SOURCE=your_LLM_source_here
+# Optional: Set the source of your LLM, for example:
+# "OpenAI", "AzureOpenAI", "Anthropic", "Ollama", "Gemini", "Bedrock", "Groq", "Custom"
+BIOMNI_SOURCE=your_LLM_source_here
 
 # Optional: AWS Bedrock Configuration (if using AWS Bedrock models)
 AWS_BEARER_TOKEN_BEDROCK=your_bedrock_api_key_here
 AWS_REGION=us-east-1
 
 # Optional: Custom model serving configuration
-# CUSTOM_MODEL_BASE_URL=http://localhost:8000/v1
-# CUSTOM_MODEL_API_KEY=your_custom_api_key_here
+# BIOMNI_CUSTOM_BASE_URL=http://localhost:8000/v1
+# BIOMNI_CUSTOM_API_KEY=your_custom_api_key_here
 
 # Optional: Biomni data path (defaults to ./data)
 # BIOMNI_DATA_PATH=/path/to/your/data
@@ -121,7 +121,7 @@ export AWS_BEARER_TOKEN_BEDROCK="YOUR_BEDROCK_API_KEY" # optional for AWS Bedroc
 export AWS_REGION="us-east-1" # optional, defaults to us-east-1 for Bedrock
 export GEMINI_API_KEY="YOUR_GEMINI_API_KEY" #optional if you want to use a gemini model
 export GROQ_API_KEY="YOUR_GROQ_API_KEY" # Optional: set this to use models served by Groq
-export LLM_SOURCE="Groq" # Optional: set this to use models served by Groq
+export BIOMNI_SOURCE="Groq" # Optional: set this to use models served by Groq
 
 
 ```


### PR DESCRIPTION
`.env.example` and the README documented `CUSTOM_MODEL_*` and `LLM_SOURCE`,
but `BiomniConfig` reads `BIOMNI_CUSTOM_BASE_URL`, `BIOMNI_CUSTOM_API_KEY`,
and `BIOMNI_SOURCE`. Following the old names left custom providers
unconfigured.

`docs/configuration.md` already uses the `BIOMNI_*` names. This change
aligns the two remaining files. `get_llm()` still accepts `LLM_SOURCE` as
a fallback; this PR does not remove that path.

Fixes #310