### PR TITLE
fix: prevent repeated failed executions

### DIFF
--- a/biomni/agent/a1.py
+++ b/biomni/agent/a1.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Generator
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 import pandas as pd
 from dotenv import load_dotenv
@@ -14,6 +14,13 @@ from langchain_core.prompts import ChatPromptTemplate
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 
+from biomni.agent.execution_guard import (
+    ExecutionFailureState,
+    blocked_execution_message,
+    record_execution_result,
+    repeated_failure_guidance,
+    should_block_execution,
+)
 from biomni.config import default_config
 from biomni.know_how import KnowHowLoader
 from biomni.llm import SourceType, get_llm
@@ -51,6 +58,7 @@ if os.path.exists(".env"):
 class AgentState(TypedDict):
     messages: list[BaseMessage]
     next_step: str | None
+    execution_failure: NotRequired[ExecutionFailureState | None]
 
 
 class A1:
@@ -1478,6 +1486,12 @@ Each library is listed with its description to help you understand its functiona
             if execute_match:
                 code = execute_match.group(1)
 
+                if should_block_execution(state.get("execution_failure"), code):
+                    observation = f"\n<observation>{blocked_execution_message()}</observation>"
+                    state["messages"].append(AIMessage(content=observation.strip()))
+                    state["next_step"] = "generate"
+                    return state
+
                 # Set timeout duration (10 minutes = 600 seconds)
                 timeout = self.timeout_seconds
 
@@ -1517,6 +1531,14 @@ Each library is listed with its description to help you understand its functiona
                     result = run_with_timeout(run_python_repl, [code], timeout=timeout)
 
                     # Plots are now captured directly in the execution entry above
+
+                state["execution_failure"] = record_execution_result(
+                    state.get("execution_failure"),
+                    code,
+                    result,
+                )
+                if state["execution_failure"] is not None and state["execution_failure"]["count"] >= 2:
+                    result += "\n\n" + repeated_failure_guidance(state["execution_failure"]["count"])
 
                 if len(result) > 10000:
                     result = (
@@ -1770,7 +1792,11 @@ Each library is listed with its description to help you understand its functiona
             selected_resources_names = self._prepare_resources_for_retrieval(prompt)
             self.update_system_prompt_with_selected_resources(selected_resources_names)
 
-        inputs = {"messages": [HumanMessage(content=prompt)], "next_step": None}
+        inputs = {
+            "messages": [HumanMessage(content=prompt)],
+            "next_step": None,
+            "execution_failure": None,
+        }
         config = {"recursion_limit": 500, "configurable": {"thread_id": 42}}
         self.log = []
 
@@ -1807,7 +1833,11 @@ Each library is listed with its description to help you understand its functiona
             selected_resources_names = self._prepare_resources_for_retrieval(prompt)
             self.update_system_prompt_with_selected_resources(selected_resources_names)
 
-        inputs = {"messages": [HumanMessage(content=prompt)], "next_step": None}
+        inputs = {
+            "messages": [HumanMessage(content=prompt)],
+            "next_step": None,
+            "execution_failure": None,
+        }
         config = {"recursion_limit": 500, "configurable": {"thread_id": 42}}
         self.log = []
 
@@ -2696,7 +2726,11 @@ Each library is listed with its description to help you understand its functiona
             agent_messages.append(HumanMessage(content=text_input))
 
             # Prepare inputs for the agent
-            inputs = {"messages": agent_messages, "next_step": None}
+            inputs = {
+                "messages": agent_messages,
+                "next_step": None,
+                "execution_failure": None,
+            }
             config = {"recursion_limit": 500, "configurable": {"thread_id": thread_id}}
 
             # Stream the agent's responses

--- a/biomni/agent/execution_guard.py
+++ b/biomni/agent/execution_guard.py
@@ -1,0 +1,86 @@
+"""Helpers for detecting repeated, identical execution failures."""
+
+import hashlib
+from typing import TypedDict
+
+MAX_IDENTICAL_FAILURES = 2
+
+
+class ExecutionFailureState(TypedDict):
+    """Serializable state for consecutive identical execution failures."""
+
+    code_signature: str
+    result_signature: str
+    count: int
+
+
+def _normalize_for_signature(value: str) -> str:
+    """Normalize platform line endings and trailing whitespace."""
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n").strip()
+    return "\n".join(line.rstrip() for line in normalized.split("\n"))
+
+
+def _signature(value: str) -> str:
+    normalized = _normalize_for_signature(value)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def is_execution_failure(result: str) -> bool:
+    """Return whether a runner result uses Biomni's standard error format."""
+    normalized = result.lstrip().casefold()
+    return normalized.startswith(("error", "timeout", "traceback"))
+
+
+def record_execution_result(
+    previous: ExecutionFailureState | None,
+    code: str,
+    result: str,
+) -> ExecutionFailureState | None:
+    """Record a failure, resetting the tracker after success or a changed failure."""
+    if not is_execution_failure(result):
+        return None
+
+    code_signature = _signature(code)
+    result_signature = _signature(result)
+    count = 1
+
+    if (
+        previous is not None
+        and previous["code_signature"] == code_signature
+        and previous["result_signature"] == result_signature
+    ):
+        count = previous["count"] + 1
+
+    return {
+        "code_signature": code_signature,
+        "result_signature": result_signature,
+        "count": count,
+    }
+
+
+def should_block_execution(
+    previous: ExecutionFailureState | None,
+    code: str,
+    max_identical_failures: int = MAX_IDENTICAL_FAILURES,
+) -> bool:
+    """Return whether code already produced the same failure too many times."""
+    if previous is None or previous["count"] < max_identical_failures:
+        return False
+
+    return previous["code_signature"] == _signature(code)
+
+
+def repeated_failure_guidance(count: int) -> str:
+    """Build feedback that asks the model to change strategy."""
+    return (
+        f"Loop guard: The same code produced the same execution failure {count} consecutive times. "
+        "Do not repeat the same code. Diagnose the failure and use a different approach."
+    )
+
+
+def blocked_execution_message() -> str:
+    """Build the observation returned when a repeated action is skipped."""
+    return (
+        "Loop guard: Execution skipped because this code already produced the same failure "
+        f"{MAX_IDENTICAL_FAILURES} consecutive times. Change the code or choose a different strategy."
+    )

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -1,0 +1,124 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from biomni.agent import A1
+from biomni.agent.execution_guard import (
+    blocked_execution_message,
+    is_execution_failure,
+    record_execution_result,
+    repeated_failure_guidance,
+    should_block_execution,
+)
+from langchain_core.messages import AIMessage, HumanMessage
+
+CODE = 'raise RuntimeError("boom")'
+ERROR = "Error: boom"
+
+
+class ExecutionGuardTests(unittest.TestCase):
+    def test_identical_failure_is_allowed_once_then_blocked(self):
+        state = record_execution_result(None, CODE, ERROR)
+
+        self.assertIsNotNone(state)
+        self.assertEqual(state["count"], 1)
+        self.assertFalse(should_block_execution(state, CODE))
+
+        state = record_execution_result(state, CODE, ERROR)
+
+        self.assertIsNotNone(state)
+        self.assertEqual(state["count"], 2)
+        self.assertTrue(should_block_execution(state, CODE))
+
+    def test_success_clears_previous_failure(self):
+        state = record_execution_result(None, CODE, ERROR)
+
+        self.assertIsNone(record_execution_result(state, CODE, "completed"))
+
+    def test_changed_code_resets_failure_count(self):
+        state = record_execution_result(None, CODE, ERROR)
+        state = record_execution_result(state, 'raise RuntimeError("different")', ERROR)
+
+        self.assertIsNotNone(state)
+        self.assertEqual(state["count"], 1)
+        self.assertFalse(should_block_execution(state, CODE))
+
+    def test_changed_failure_resets_failure_count(self):
+        state = record_execution_result(None, CODE, ERROR)
+        state = record_execution_result(state, CODE, "Error: a different failure")
+
+        self.assertIsNotNone(state)
+        self.assertEqual(state["count"], 1)
+        self.assertFalse(should_block_execution(state, CODE))
+
+    def test_line_ending_and_trailing_whitespace_differences_are_ignored(self):
+        state = record_execution_result(None, "line_one()  \r\nline_two()", "Error: boom\r\n")
+        state = record_execution_result(state, "line_one()\nline_two()  ", "Error: boom\n")
+
+        self.assertIsNotNone(state)
+        self.assertEqual(state["count"], 2)
+        self.assertTrue(should_block_execution(state, "line_one()\nline_two()"))
+
+    def test_non_error_text_does_not_count_as_failure(self):
+        self.assertFalse(is_execution_failure("Analysis completed with no error"))
+        self.assertIsNone(record_execution_result(None, CODE, "Analysis completed with no error"))
+
+    def test_standard_executor_failures_are_detected(self):
+        self.assertTrue(is_execution_failure("Error: invalid syntax"))
+        self.assertTrue(is_execution_failure("ERROR: Code execution timed out"))
+        self.assertTrue(is_execution_failure("Traceback (most recent call last):"))
+
+    def test_recovery_messages_tell_the_model_to_change_strategy(self):
+        self.assertIn("Do not repeat the same code", repeated_failure_guidance(2))
+        self.assertIn("Execution skipped", blocked_execution_message())
+        self.assertIn("different strategy", blocked_execution_message())
+
+    def test_a1_skips_third_identical_failed_execution(self):
+        class StubLLM:
+            def __init__(self):
+                self.responses = iter(
+                    [
+                        AIMessage(content=f"<execute>{CODE}</execute>"),
+                        AIMessage(content=f"<execute>{CODE}</execute>"),
+                        AIMessage(content=f"<execute>{CODE}</execute>"),
+                        AIMessage(content="<solution>Recovered safely.</solution>"),
+                    ]
+                )
+
+            def invoke(self, _messages):
+                return next(self.responses)
+
+        with TemporaryDirectory() as temp_dir:
+            agent = A1.__new__(A1)
+            agent.path = str(Path(temp_dir))
+            agent.data_lake_dict = {}
+            agent.library_content_dict = {}
+            agent.module2api = {}
+            agent.know_how_loader = SimpleNamespace(documents={})
+            agent.llm = StubLLM()
+            agent.timeout_seconds = 1
+            agent._generate_system_prompt = lambda **_kwargs: "Test system prompt"
+            agent._clear_execution_plots = lambda: None
+            agent._inject_custom_functions_to_repl = lambda: None
+            agent.configure()
+
+            inputs = {
+                "messages": [HumanMessage(content="Run failing code")],
+                "next_step": None,
+                "execution_failure": None,
+            }
+            config = {"recursion_limit": 20, "configurable": {"thread_id": "loop-guard-test"}}
+
+            with patch("biomni.agent.a1.run_with_timeout", return_value=ERROR) as run_code:
+                states = list(agent.app.stream(inputs, stream_mode="values", config=config))
+
+        self.assertEqual(run_code.call_count, 2)
+        final_messages = states[-1]["messages"]
+        self.assertTrue(any("Execution skipped" in str(message.content) for message in final_messages))
+        self.assertIn("<solution>Recovered safely.</solution>", str(final_messages[-1].content))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- track consecutive identical failed code executions in A1
- add explicit recovery guidance after the second identical failure
- skip the third identical execution before invoking the runner
- reset the failure state after success, changed code, or a changed error
- cover the guard and LangGraph integration path with focused tests

## Why

A1 can repeatedly execute the same failing code, consuming the recursion/token budget without making progress. This adds a narrow execution guard without changing the graph recursion-limit or checkpoint behavior.

Relates to #272.

## Tests

- `python -m pytest tests/test_execution_guard.py -q` — 9 passed
- `ruff check biomni/agent/a1.py biomni/agent/execution_guard.py tests/test_execution_guard.py`
- `ruff format --check biomni/agent/a1.py biomni/agent/execution_guard.py tests/test_execution_guard.py`