### PR TITLE
Europe pmc feature

### DIFF
--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -246,7 +246,7 @@ def query_europe_pmc(query: str, max_papers: int = 10, max_retries: int = 3) -> 
         if not search_query:
             return "Error querying Europe PMC: Query must not be empty."
 
-        page_size = max(1, min(int(max_papers), 25))
+        page_size = max(1, int(max_papers))
         retries = max(0, int(max_retries))
         records = _search_europe_pmc(search_query, page_size=page_size)
 

--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -183,6 +183,89 @@ def query_pubmed(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
         return f"Error querying PubMed: {e}"
 
 
+def _extract_europe_pmc_records(payload: dict) -> list[dict]:
+    result_list = payload.get("resultList", {}).get("result", [])
+    if isinstance(result_list, list):
+        return [record for record in result_list if isinstance(record, dict)]
+    return []
+
+
+def _simplify_europe_pmc_query(query: str, retry_index: int) -> str:
+    parts = query.split()
+    if len(parts) > retry_index:
+        return " ".join(parts[:-retry_index])
+    return query
+
+
+def _format_europe_pmc_record(record: dict) -> str:
+    title = record.get("title") or "N/A"
+    abstract = record.get("abstractText") or "No abstract available."
+    journal_info = record.get("journalInfo", {})
+    journal = (
+        record.get("journalTitle")
+        or record.get("journalAbbreviation")
+        or journal_info.get("journal", {}).get("title")
+        or journal_info.get("journal", {}).get("isoabbreviation")
+        or "N/A"
+    )
+    return f"Title: {title}\nAbstract: {abstract}\nJournal: {journal}"
+
+
+def _search_europe_pmc(query: str, page_size: int = 25, session: requests.Session | None = None) -> list[dict]:
+    active_session = session or requests.Session()
+    response = active_session.get(
+        "https://www.ebi.ac.uk/europepmc/webservices/rest/search",
+        params={
+            "query": query,
+            "format": "json",
+            "resultType": "core",
+            "pageSize": page_size,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return _extract_europe_pmc_records(response.json())
+
+
+def query_europe_pmc(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
+    """Query Europe PMC for papers based on the provided search query.
+
+    Parameters
+    ----------
+    - query (str): The search query string.
+    - max_papers (int): The maximum number of papers to retrieve (default: 10).
+    - max_retries (int): Maximum number of retry attempts with modified queries (default: 3).
+
+    Returns
+    -------
+    - str: The formatted search results or an error message.
+
+    """
+    try:
+        search_query = query.strip()
+        if not search_query:
+            return "Error querying Europe PMC: Query must not be empty."
+
+        page_size = max(1, min(int(max_papers), 25))
+        retries = max(0, int(max_retries))
+        records = _search_europe_pmc(search_query, page_size=page_size)
+
+        retry_count = 0
+        while not records and retry_count < retries:
+            retry_count += 1
+            search_query = _simplify_europe_pmc_query(search_query, retry_count)
+            time.sleep(1)
+            records = _search_europe_pmc(search_query, page_size=page_size)
+
+        if records:
+            return "\n\n".join(_format_europe_pmc_record(record) for record in records[:page_size])
+        return "No papers found on Europe PMC after multiple query attempts."
+    except requests.RequestException as e:
+        return f"Error querying Europe PMC: {e}"
+    except ValueError as e:
+        return f"Error querying Europe PMC: {e}"
+
+
 def search_google(query: str, num_results: int = 3, language: str = "en") -> list[dict]:
     """Search using Google search.
 

--- a/biomni/tool/tool_description/literature.py
+++ b/biomni/tool/tool_description/literature.py
@@ -1,5 +1,31 @@
 description = [
     {
+        "description": "Query Europe PMC for papers based on the provided search query.",
+        "name": "query_europe_pmc",
+        "optional_parameters": [
+            {
+                "default": 10,
+                "description": "The maximum number of papers to retrieve.",
+                "name": "max_papers",
+                "type": "int",
+            },
+            {
+                "default": 3,
+                "description": "Maximum number of retry attempts with modified queries.",
+                "name": "max_retries",
+                "type": "int",
+            },
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The search query string. Europe PMC fielded queries such as ABSTRACT:\"single cell\" are supported.",
+                "name": "query",
+                "type": "str",
+            },
+        ],
+    },
+    {
         "description": "Fetches supplementary information for a paper given its DOI "
         "and saves it to a specified directory.",
         "name": "fetch_supplementary_info_from_doi",

--- a/biomni/tool/tool_description/literature.py
+++ b/biomni/tool/tool_description/literature.py
@@ -19,7 +19,7 @@ description = [
         "required_parameters": [
             {
                 "default": None,
-                "description": "The search query string. Europe PMC fielded queries such as ABSTRACT:\"single cell\" are supported.",
+                "description": 'The search query string. Europe PMC fielded queries such as ABSTRACT:"single cell" are supported.',
                 "name": "query",
                 "type": "str",
             },

--- a/tests/fixtures/conformance_edge_cases.json
+++ b/tests/fixtures/conformance_edge_cases.json
@@ -1,0 +1,46 @@
+{
+  "attribution": {
+    "provider": "Europe PMC",
+    "derived_from": "europe_pmc_2020.json",
+    "source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID%3A33180112%20AND%20SRC%3AMED&resultType=core&format=json&pageSize=2",
+    "note": "Contract-conformance variants derived from the attributed recording by removing optional fields or duplicating exact-match records. They are not represented as independent upstream observations."
+  },
+  "missing_optional": {
+    "id": "33180112",
+    "source": "MED",
+    "pmid": "33180112",
+    "title": "Europe PMC in 2020.",
+    "authorList": {"author": [{"fullName": "Ferguson C"}]},
+    "isOpenAccess": null,
+    "inEPMC": "N"
+  },
+  "multiple_affiliations": {
+    "id": "33180112",
+    "source": "MED",
+    "pmid": "33180112",
+    "title": "Europe PMC in 2020.",
+    "authorList": {
+      "author": [
+        {
+          "fullName": "Example E",
+          "authorAffiliationDetailsList": {
+            "authorAffiliation": [
+              {"affiliation": "Institute One"},
+              {"affiliation": "Institute Two"}
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "ambiguous_response": {
+    "version": "6.9",
+    "hitCount": 2,
+    "resultList": {
+      "result": [
+        {"id": "33180112", "source": "MED", "pmid": "33180112", "pmcid": "PMC7778976", "doi": "10.1093/nar/gkaa994", "title": "Europe PMC in 2020."},
+        {"id": "33180112", "source": "MED", "pmid": "33180112", "pmcid": "PMC7778976", "doi": "10.1093/nar/gkaa994", "title": "Europe PMC in 2020."}
+      ]
+    }
+  }
+}

--- a/tests/fixtures/conformance_edge_cases.json
+++ b/tests/fixtures/conformance_edge_cases.json
@@ -1,46 +1,60 @@
 {
-  "attribution": {
-    "provider": "Europe PMC",
-    "derived_from": "europe_pmc_2020.json",
-    "source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID%3A33180112%20AND%20SRC%3AMED&resultType=core&format=json&pageSize=2",
-    "note": "Contract-conformance variants derived from the attributed recording by removing optional fields or duplicating exact-match records. They are not represented as independent upstream observations."
-  },
-  "missing_optional": {
-    "id": "33180112",
-    "source": "MED",
-    "pmid": "33180112",
-    "title": "Europe PMC in 2020.",
-    "authorList": {"author": [{"fullName": "Ferguson C"}]},
-    "isOpenAccess": null,
-    "inEPMC": "N"
-  },
-  "multiple_affiliations": {
-    "id": "33180112",
-    "source": "MED",
-    "pmid": "33180112",
-    "title": "Europe PMC in 2020.",
-    "authorList": {
-      "author": [
-        {
-          "fullName": "Example E",
-          "authorAffiliationDetailsList": {
-            "authorAffiliation": [
-              {"affiliation": "Institute One"},
-              {"affiliation": "Institute Two"}
-            ]
-          }
-        }
-      ]
-    }
-  },
-  "ambiguous_response": {
-    "version": "6.9",
-    "hitCount": 2,
-    "resultList": {
-      "result": [
-        {"id": "33180112", "source": "MED", "pmid": "33180112", "pmcid": "PMC7778976", "doi": "10.1093/nar/gkaa994", "title": "Europe PMC in 2020."},
-        {"id": "33180112", "source": "MED", "pmid": "33180112", "pmcid": "PMC7778976", "doi": "10.1093/nar/gkaa994", "title": "Europe PMC in 2020."}
-      ]
-    }
-  }
+	"attribution": {
+		"provider": "Europe PMC",
+		"derived_from": "europe_pmc_2020.json",
+		"source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID%3A33180112%20AND%20SRC%3AMED&resultType=core&format=json&pageSize=2",
+		"note": "Contract-conformance variants derived from the attributed recording by removing optional fields or duplicating exact-match records. They are not represented as independent upstream observations."
+	},
+	"missing_optional": {
+		"id": "33180112",
+		"source": "MED",
+		"pmid": "33180112",
+		"title": "Europe PMC in 2020.",
+		"authorList": { "author": [{ "fullName": "Ferguson C" }] },
+		"isOpenAccess": null,
+		"inEPMC": "N"
+	},
+	"multiple_affiliations": {
+		"id": "33180112",
+		"source": "MED",
+		"pmid": "33180112",
+		"title": "Europe PMC in 2020.",
+		"authorList": {
+			"author": [
+				{
+					"fullName": "Example E",
+					"authorAffiliationDetailsList": {
+						"authorAffiliation": [
+							{ "affiliation": "Institute One" },
+							{ "affiliation": "Institute Two" }
+						]
+					}
+				}
+			]
+		}
+	},
+	"ambiguous_response": {
+		"version": "6.9",
+		"hitCount": 2,
+		"resultList": {
+			"result": [
+				{
+					"id": "33180112",
+					"source": "MED",
+					"pmid": "33180112",
+					"pmcid": "PMC7778976",
+					"doi": "10.1093/nar/gkaa994",
+					"title": "Europe PMC in 2020."
+				},
+				{
+					"id": "33180112",
+					"source": "MED",
+					"pmid": "33180112",
+					"pmcid": "PMC7778976",
+					"doi": "10.1093/nar/gkaa994",
+					"title": "Europe PMC in 2020."
+				}
+			]
+		}
+	}
 }

--- a/tests/fixtures/europe_pmc_2020.json
+++ b/tests/fixtures/europe_pmc_2020.json
@@ -1,0 +1,77 @@
+{
+  "attribution": {
+    "provider": "Europe PMC",
+    "source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID%3A33180112%20AND%20SRC%3AMED&resultType=core&format=json&pageSize=2",
+    "retrieved_date": "2026-08-30",
+    "note": "Recorded core response reduced only by removing fields outside this capability's contract."
+  },
+  "response": {
+    "version": "6.9",
+    "hitCount": 1,
+    "request": {
+      "queryString": "EXT_ID:33180112 AND SRC:MED",
+      "resultType": "CORE",
+      "pageSize": 2
+    },
+    "resultList": {
+      "result": [
+        {
+          "id": "33180112",
+          "source": "MED",
+          "pmid": "33180112",
+          "pmcid": "PMC7778976",
+          "doi": "10.1093/nar/gkaa994",
+          "title": "Europe PMC in 2020.",
+          "authorList": {
+            "author": [
+              {
+                "fullName": "Ferguson C",
+                "firstName": "Christine",
+                "lastName": "Ferguson",
+                "initials": "C",
+                "authorId": {"type": "ORCID", "value": "0000-0002-9317-6819"},
+                "authorAffiliationDetailsList": {
+                  "authorAffiliation": [
+                    {"affiliation": "Literature Services, EMBL-EBI, Wellcome Trust Genome Campus, Cambridge, UK."}
+                  ]
+                }
+              },
+              {
+                "fullName": "Araújo D",
+                "firstName": "Dayane",
+                "lastName": "Araújo",
+                "initials": "D",
+                "authorAffiliationDetailsList": {
+                  "authorAffiliation": [
+                    {"affiliation": "Literature Services, EMBL-EBI, Wellcome Trust Genome Campus, Cambridge, UK."}
+                  ]
+                }
+              }
+            ]
+          },
+          "journalInfo": {
+            "issue": "D1",
+            "volume": "49",
+            "printPublicationDate": "2021-01-01",
+            "journal": {
+              "title": "Nucleic acids research",
+              "issn": "0305-1048",
+              "essn": "1362-4962",
+              "isoabbreviation": "Nucleic Acids Res"
+            }
+          },
+          "pubYear": "2021",
+          "pageInfo": "D1507-D1514",
+          "abstractText": "Europe PMC (https://europepmc.org) is a database of research articles, including peer reviewed full text articles and abstracts, and preprints - all freely available for use via website, APIs and bulk download. This article outlines new developments since 2017 where work has focussed on three key areas: (i) Europe PMC has added to its core content to include life science preprint abstracts and a special collection of full text of COVID-19-related preprints. Europe PMC is unique as an aggregator of biomedical preprints alongside peer-reviewed articles, with over 180 000 preprints available to search. (ii) Europe PMC has significantly expanded its links to content related to the publications, such as links to Unpaywall, providing wider access to full text, preprint peer-review platforms, all major curated data resources in the life sciences, and experimental protocols. The redesigned Europe PMC website features the PubMed abstract and corresponding PMC full text merged into one article page; there is more evident and user-friendly navigation within articles and to related content, plus a figure browse feature. (iii) The expanded annotations platform offers ∼1.3 billion text mined biological terms and concepts sourced from 10 providers and over 40 global data resources.",
+          "language": "eng",
+          "pubTypeList": {"pubType": ["research-article", "Journal Article"]},
+          "isOpenAccess": "Y",
+          "inEPMC": "Y",
+          "inPMC": "Y",
+          "license": "cc by",
+          "firstPublicationDate": "2021-01-01"
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/europe_pmc_2020.json
+++ b/tests/fixtures/europe_pmc_2020.json
@@ -1,77 +1,81 @@
 {
-  "attribution": {
-    "provider": "Europe PMC",
-    "source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID%3A33180112%20AND%20SRC%3AMED&resultType=core&format=json&pageSize=2",
-    "retrieved_date": "2026-08-30",
-    "note": "Recorded core response reduced only by removing fields outside this capability's contract."
-  },
-  "response": {
-    "version": "6.9",
-    "hitCount": 1,
-    "request": {
-      "queryString": "EXT_ID:33180112 AND SRC:MED",
-      "resultType": "CORE",
-      "pageSize": 2
-    },
-    "resultList": {
-      "result": [
-        {
-          "id": "33180112",
-          "source": "MED",
-          "pmid": "33180112",
-          "pmcid": "PMC7778976",
-          "doi": "10.1093/nar/gkaa994",
-          "title": "Europe PMC in 2020.",
-          "authorList": {
-            "author": [
-              {
-                "fullName": "Ferguson C",
-                "firstName": "Christine",
-                "lastName": "Ferguson",
-                "initials": "C",
-                "authorId": {"type": "ORCID", "value": "0000-0002-9317-6819"},
-                "authorAffiliationDetailsList": {
-                  "authorAffiliation": [
-                    {"affiliation": "Literature Services, EMBL-EBI, Wellcome Trust Genome Campus, Cambridge, UK."}
-                  ]
-                }
-              },
-              {
-                "fullName": "Araújo D",
-                "firstName": "Dayane",
-                "lastName": "Araújo",
-                "initials": "D",
-                "authorAffiliationDetailsList": {
-                  "authorAffiliation": [
-                    {"affiliation": "Literature Services, EMBL-EBI, Wellcome Trust Genome Campus, Cambridge, UK."}
-                  ]
-                }
-              }
-            ]
-          },
-          "journalInfo": {
-            "issue": "D1",
-            "volume": "49",
-            "printPublicationDate": "2021-01-01",
-            "journal": {
-              "title": "Nucleic acids research",
-              "issn": "0305-1048",
-              "essn": "1362-4962",
-              "isoabbreviation": "Nucleic Acids Res"
-            }
-          },
-          "pubYear": "2021",
-          "pageInfo": "D1507-D1514",
-          "abstractText": "Europe PMC (https://europepmc.org) is a database of research articles, including peer reviewed full text articles and abstracts, and preprints - all freely available for use via website, APIs and bulk download. This article outlines new developments since 2017 where work has focussed on three key areas: (i) Europe PMC has added to its core content to include life science preprint abstracts and a special collection of full text of COVID-19-related preprints. Europe PMC is unique as an aggregator of biomedical preprints alongside peer-reviewed articles, with over 180 000 preprints available to search. (ii) Europe PMC has significantly expanded its links to content related to the publications, such as links to Unpaywall, providing wider access to full text, preprint peer-review platforms, all major curated data resources in the life sciences, and experimental protocols. The redesigned Europe PMC website features the PubMed abstract and corresponding PMC full text merged into one article page; there is more evident and user-friendly navigation within articles and to related content, plus a figure browse feature. (iii) The expanded annotations platform offers ∼1.3 billion text mined biological terms and concepts sourced from 10 providers and over 40 global data resources.",
-          "language": "eng",
-          "pubTypeList": {"pubType": ["research-article", "Journal Article"]},
-          "isOpenAccess": "Y",
-          "inEPMC": "Y",
-          "inPMC": "Y",
-          "license": "cc by",
-          "firstPublicationDate": "2021-01-01"
-        }
-      ]
-    }
-  }
+	"attribution": {
+		"provider": "Europe PMC",
+		"source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID%3A33180112%20AND%20SRC%3AMED&resultType=core&format=json&pageSize=2",
+		"retrieved_date": "2026-08-30",
+		"note": "Recorded core response reduced only by removing fields outside this capability's contract."
+	},
+	"response": {
+		"version": "6.9",
+		"hitCount": 1,
+		"request": {
+			"queryString": "EXT_ID:33180112 AND SRC:MED",
+			"resultType": "CORE",
+			"pageSize": 2
+		},
+		"resultList": {
+			"result": [
+				{
+					"id": "33180112",
+					"source": "MED",
+					"pmid": "33180112",
+					"pmcid": "PMC7778976",
+					"doi": "10.1093/nar/gkaa994",
+					"title": "Europe PMC in 2020.",
+					"authorList": {
+						"author": [
+							{
+								"fullName": "Ferguson C",
+								"firstName": "Christine",
+								"lastName": "Ferguson",
+								"initials": "C",
+								"authorId": { "type": "ORCID", "value": "0000-0002-9317-6819" },
+								"authorAffiliationDetailsList": {
+									"authorAffiliation": [
+										{
+											"affiliation": "Literature Services, EMBL-EBI, Wellcome Trust Genome Campus, Cambridge, UK."
+										}
+									]
+								}
+							},
+							{
+								"fullName": "Araújo D",
+								"firstName": "Dayane",
+								"lastName": "Araújo",
+								"initials": "D",
+								"authorAffiliationDetailsList": {
+									"authorAffiliation": [
+										{
+											"affiliation": "Literature Services, EMBL-EBI, Wellcome Trust Genome Campus, Cambridge, UK."
+										}
+									]
+								}
+							}
+						]
+					},
+					"journalInfo": {
+						"issue": "D1",
+						"volume": "49",
+						"printPublicationDate": "2021-01-01",
+						"journal": {
+							"title": "Nucleic acids research",
+							"issn": "0305-1048",
+							"essn": "1362-4962",
+							"isoabbreviation": "Nucleic Acids Res"
+						}
+					},
+					"pubYear": "2021",
+					"pageInfo": "D1507-D1514",
+					"abstractText": "Europe PMC (https://europepmc.org) is a database of research articles, including peer reviewed full text articles and abstracts, and preprints - all freely available for use via website, APIs and bulk download. This article outlines new developments since 2017 where work has focussed on three key areas: (i) Europe PMC has added to its core content to include life science preprint abstracts and a special collection of full text of COVID-19-related preprints. Europe PMC is unique as an aggregator of biomedical preprints alongside peer-reviewed articles, with over 180 000 preprints available to search. (ii) Europe PMC has significantly expanded its links to content related to the publications, such as links to Unpaywall, providing wider access to full text, preprint peer-review platforms, all major curated data resources in the life sciences, and experimental protocols. The redesigned Europe PMC website features the PubMed abstract and corresponding PMC full text merged into one article page; there is more evident and user-friendly navigation within articles and to related content, plus a figure browse feature. (iii) The expanded annotations platform offers ∼1.3 billion text mined biological terms and concepts sourced from 10 providers and over 40 global data resources.",
+					"language": "eng",
+					"pubTypeList": { "pubType": ["research-article", "Journal Article"] },
+					"isOpenAccess": "Y",
+					"inEPMC": "Y",
+					"inPMC": "Y",
+					"license": "cc by",
+					"firstPublicationDate": "2021-01-01"
+				}
+			]
+		}
+	}
 }

--- a/tests/fixtures/preprint.json
+++ b/tests/fixtures/preprint.json
@@ -1,34 +1,39 @@
 {
-  "attribution": {
-    "provider": "Europe PMC",
-    "source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=SRC%3APPR&resultType=core&format=json&pageSize=1",
-    "retrieved_date": "2026-08-30",
-    "note": "Recorded core response reduced only by removing fields outside this capability's contract."
-  },
-  "response": {
-    "version": "6.9",
-    "hitCount": 1,
-    "resultList": {
-      "result": [
-        {
-          "id": "PPR1306089",
-          "source": "PPR",
-          "doi": "10.64898/2026.08.24.746774",
-          "title": "Assay concordance sets exact ceilings on what one biological score can predict",
-          "authorList": {
-            "author": [
-              {"fullName": "Liu Z", "firstName": "Zongmin", "lastName": "Liu", "initials": "Z"}
-            ]
-          },
-          "pubYear": "2026",
-          "abstractText": "Computational models of biology are ranked by averaging one prediction against many experimental realizations of a phenotype that are treated as interchangeable. We show this imposes an exact, model-free ceiling fixed by how much those realizations agree with each other, and that the ceiling depends on the evaluation metric through a single support-function identity.",
-          "pubTypeList": {"pubType": ["Preprint"]},
-          "isOpenAccess": "N",
-          "inEPMC": "N",
-          "inPMC": "N",
-          "firstPublicationDate": "2026-08-26"
-        }
-      ]
-    }
-  }
+	"attribution": {
+		"provider": "Europe PMC",
+		"source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=SRC%3APPR&resultType=core&format=json&pageSize=1",
+		"retrieved_date": "2026-08-30",
+		"note": "Recorded core response reduced only by removing fields outside this capability's contract."
+	},
+	"response": {
+		"version": "6.9",
+		"hitCount": 1,
+		"resultList": {
+			"result": [
+				{
+					"id": "PPR1306089",
+					"source": "PPR",
+					"doi": "10.64898/2026.08.24.746774",
+					"title": "Assay concordance sets exact ceilings on what one biological score can predict",
+					"authorList": {
+						"author": [
+							{
+								"fullName": "Liu Z",
+								"firstName": "Zongmin",
+								"lastName": "Liu",
+								"initials": "Z"
+							}
+						]
+					},
+					"pubYear": "2026",
+					"abstractText": "Computational models of biology are ranked by averaging one prediction against many experimental realizations of a phenotype that are treated as interchangeable. We show this imposes an exact, model-free ceiling fixed by how much those realizations agree with each other, and that the ceiling depends on the evaluation metric through a single support-function identity.",
+					"pubTypeList": { "pubType": ["Preprint"] },
+					"isOpenAccess": "N",
+					"inEPMC": "N",
+					"inPMC": "N",
+					"firstPublicationDate": "2026-08-26"
+				}
+			]
+		}
+	}
 }

--- a/tests/fixtures/preprint.json
+++ b/tests/fixtures/preprint.json
@@ -1,0 +1,34 @@
+{
+  "attribution": {
+    "provider": "Europe PMC",
+    "source_url": "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=SRC%3APPR&resultType=core&format=json&pageSize=1",
+    "retrieved_date": "2026-08-30",
+    "note": "Recorded core response reduced only by removing fields outside this capability's contract."
+  },
+  "response": {
+    "version": "6.9",
+    "hitCount": 1,
+    "resultList": {
+      "result": [
+        {
+          "id": "PPR1306089",
+          "source": "PPR",
+          "doi": "10.64898/2026.08.24.746774",
+          "title": "Assay concordance sets exact ceilings on what one biological score can predict",
+          "authorList": {
+            "author": [
+              {"fullName": "Liu Z", "firstName": "Zongmin", "lastName": "Liu", "initials": "Z"}
+            ]
+          },
+          "pubYear": "2026",
+          "abstractText": "Computational models of biology are ranked by averaging one prediction against many experimental realizations of a phenotype that are treated as interchangeable. We show this imposes an exact, model-free ceiling fixed by how much those realizations agree with each other, and that the ceiling depends on the evaluation metric through a single support-function identity.",
+          "pubTypeList": {"pubType": ["Preprint"]},
+          "isOpenAccess": "N",
+          "inEPMC": "N",
+          "inPMC": "N",
+          "firstPublicationDate": "2026-08-26"
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_europe_pmc.py
+++ b/tests/test_europe_pmc.py
@@ -97,6 +97,19 @@ def test_query_europe_pmc_returns_error_string_on_http_error(monkeypatch):
     assert result == "Error querying Europe PMC: 429 Client Error"
 
 
+def test_query_europe_pmc_passes_max_papers_through(monkeypatch):
+    page_sizes = []
+
+    def fake_search(query, page_size=25):
+        del query
+        page_sizes.append(page_size)
+        return []
+
+    monkeypatch.setattr(literature, "_search_europe_pmc", fake_search)
+    literature.query_europe_pmc("malaria", max_papers=100, max_retries=0)
+    assert page_sizes == [100]
+
+
 def test_query_europe_pmc_rejects_empty_query():
     result = literature.query_europe_pmc("   ")
     assert result == "Error querying Europe PMC: Query must not be empty."

--- a/tests/test_europe_pmc.py
+++ b/tests/test_europe_pmc.py
@@ -1,0 +1,110 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+from biomni.tool import literature
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+@pytest.fixture
+def fixture_payload() -> dict:
+    return json.loads((FIXTURES_DIR / "europe_pmc_2020.json").read_text(encoding="utf-8"))["response"]
+
+
+def test_extract_records_ignores_non_lists():
+    assert literature._extract_europe_pmc_records({}) == []
+    assert literature._extract_europe_pmc_records({"resultList": {"result": {"id": "1"}}}) == []
+
+
+def test_format_record_uses_abstract_and_journal():
+    record = {
+        "title": "Europe PMC in 2020.",
+        "abstractText": "Europe PMC is a database of life science literature.",
+        "journalTitle": "Nucleic acids research",
+    }
+    output = literature._format_europe_pmc_record(record)
+    assert "Title: Europe PMC in 2020." in output
+    assert "Abstract: Europe PMC is a database of life science literature." in output
+    assert "Journal: Nucleic acids research" in output
+
+
+def test_search_europe_pmc_returns_records(fixture_payload, monkeypatch):
+    session = Mock()
+    session.get.return_value = Response(fixture_payload)
+    records = literature._search_europe_pmc('TITLE:"Europe PMC"', page_size=2, session=session)
+    assert records[0]["pmid"] == "33180112"
+    session.get.assert_called_once()
+
+
+def test_query_europe_pmc_returns_formatted_results(fixture_payload, monkeypatch):
+    monkeypatch.setattr(
+        literature,
+        "_search_europe_pmc",
+        lambda query, page_size=25: literature._extract_europe_pmc_records(fixture_payload),
+    )
+    result = literature.query_europe_pmc('ABSTRACT:"Europe PMC"', max_papers=1, max_retries=0)
+    assert "Title: Europe PMC in 2020." in result
+    assert "Abstract: Europe PMC (https://europepmc.org) is a database" in result
+    assert "Journal: Nucleic acids research" in result
+
+
+def test_query_europe_pmc_retries_with_simplified_query(monkeypatch):
+    queries = []
+
+    def fake_search(query, page_size=25):
+        queries.append(query)
+        if len(queries) == 1:
+            return []
+        return [{"title": "Paper", "abstractText": "Abstract", "journalTitle": "Journal"}]
+
+    monkeypatch.setattr(literature, "_search_europe_pmc", fake_search)
+    monkeypatch.setattr(literature.time, "sleep", lambda seconds: None)
+    result = literature.query_europe_pmc("single cell atlases", max_papers=1, max_retries=1)
+    assert queries == ["single cell atlases", "single cell"]
+    assert "Title: Paper" in result
+
+
+def test_query_europe_pmc_returns_no_results_message(monkeypatch):
+    monkeypatch.setattr(literature, "_search_europe_pmc", lambda query, page_size=25: [])
+    result = literature.query_europe_pmc("missing", max_papers=1, max_retries=1)
+    assert result == "No papers found on Europe PMC after multiple query attempts."
+
+
+def test_query_europe_pmc_returns_error_string_on_http_error(monkeypatch):
+    def fake_search(query, page_size=25):
+        raise requests.HTTPError("429 Client Error")
+
+    monkeypatch.setattr(literature, "_search_europe_pmc", fake_search)
+    result = literature.query_europe_pmc("malaria")
+    assert result == "Error querying Europe PMC: 429 Client Error"
+
+
+def test_query_europe_pmc_rejects_empty_query():
+    result = literature.query_europe_pmc("   ")
+    assert result == "Error querying Europe PMC: Query must not be empty."
+
+
+def test_literature_tool_description_exposes_only_query_tool():
+    from biomni.tool.tool_description.literature import description
+
+    names = [tool["name"] for tool in description]
+    assert "query_europe_pmc" in names
+    assert "query_pubmed" in names


### PR DESCRIPTION
## Summary

Add query_europe_pmc to Biomni’s literature tools.

## Validation

Tested locally on September 2, 2026.

pytest -q /workspace/Biomni/tests/test_europe_pmc.py
ruff check /workspace/Biomni/biomni/tool/literature.py /
workspace/Biomni/biomni/tool/tool_description/literature.py /
workspace/Biomni/tests/test_europe_pmc.py

Also smoke-tested locally through Biomni using
Qwen/Qwen2.5-7B-Instruct-AWQ.

## Example prompt

Find one paper about Europe PMC in 2020 and summarize the
abstract.