### PR TITLE
Crossref

### DIFF
--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -183,6 +183,96 @@ def query_pubmed(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
         return f"Error querying PubMed: {e}"
 
 
+def _extract_crossref_records(payload: dict) -> list[dict]:
+    items = payload.get("message", {}).get("items", [])
+    if isinstance(items, list):
+        return [record for record in items if isinstance(record, dict)]
+    return []
+
+
+def _simplify_crossref_query(query: str, retry_index: int) -> str:
+    parts = query.split()
+    if len(parts) > retry_index:
+        return " ".join(parts[:-retry_index])
+    return query
+
+
+def _get_first_crossref_value(value) -> str:
+    if isinstance(value, list) and value:
+        return str(value[0])
+    if isinstance(value, str):
+        return value
+    return "N/A"
+
+
+def _format_crossref_record(record: dict) -> str:
+    title = _get_first_crossref_value(record.get("title"))
+    abstract = record.get("abstract") or "No abstract available."
+    if abstract != "No abstract available.":
+        abstract = BeautifulSoup(abstract, "html.parser").get_text(" ", strip=True)
+    journal = _get_first_crossref_value(record.get("container-title"))
+    return f"Title: {title}\nAbstract: {abstract}\nJournal: {journal}"
+
+
+def _search_crossref(query: str, page_size: int = 25, session: requests.Session | None = None) -> list[dict]:
+    active_session = session or requests.Session()
+    params = {
+        "query": query,
+        "rows": page_size,
+        "select": "DOI,title,abstract,container-title",
+    }
+    mailto = os.getenv("CROSSREF_MAILTO")
+    if mailto:
+        params["mailto"] = mailto
+
+    response = active_session.get(
+        "https://api.crossref.org/works",
+        params=params,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return _extract_crossref_records(response.json())
+
+
+def query_crossref(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
+    """Query Crossref for papers based on the provided search query.
+
+    Parameters
+    ----------
+    - query (str): The search query string.
+    - max_papers (int): The maximum number of papers to retrieve (default: 10).
+    - max_retries (int): Maximum number of retry attempts with modified queries (default: 3).
+
+    Returns
+    -------
+    - str: The formatted search results or an error message.
+
+    """
+    try:
+        search_query = query.strip()
+        if not search_query:
+            return "Error querying Crossref: Query must not be empty."
+
+        page_size = max(1, int(max_papers))
+        retries = max(0, int(max_retries))
+        records = _search_crossref(search_query, page_size=page_size)
+
+        retry_count = 0
+        while not records and retry_count < retries:
+            retry_count += 1
+            search_query = _simplify_crossref_query(search_query, retry_count)
+            time.sleep(1)
+            records = _search_crossref(search_query, page_size=page_size)
+
+        if records:
+            return "\n\n".join(_format_crossref_record(record) for record in records[:page_size])
+        return "No papers found on Crossref after multiple query attempts."
+    except requests.RequestException as e:
+        return f"Error querying Crossref: {e}"
+    except ValueError as e:
+        return f"Error querying Crossref: {e}"
+
+
 def search_google(query: str, num_results: int = 3, language: str = "en") -> list[dict]:
     """Search using Google search.
 

--- a/biomni/tool/tool_description/literature.py
+++ b/biomni/tool/tool_description/literature.py
@@ -1,5 +1,31 @@
 description = [
     {
+        "description": "Query Crossref for papers based on the provided search query.",
+        "name": "query_crossref",
+        "optional_parameters": [
+            {
+                "default": 10,
+                "description": "The maximum number of papers to retrieve.",
+                "name": "max_papers",
+                "type": "int",
+            },
+            {
+                "default": 3,
+                "description": "Maximum number of retry attempts with modified queries.",
+                "name": "max_retries",
+                "type": "int",
+            },
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The search query string.",
+                "name": "query",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Fetches supplementary information for a paper given its DOI "
         "and saves it to a specified directory.",
         "name": "fetch_supplementary_info_from_doi",

--- a/tests/fixtures/crossref_crispr.json
+++ b/tests/fixtures/crossref_crispr.json
@@ -1,31 +1,31 @@
 {
-  "attribution": {
-    "provider": "Crossref",
-    "source_url": "https://api.crossref.org/works?query=CRISPR&rows=1&select=DOI,title,abstract,container-title,published-print,published-online",
-    "retrieved_date": "2026-09-05",
-    "note": "Recorded response reduced only by removing fields outside this capability's contract."
-  },
-  "response": {
-    "status": "ok",
-    "message-type": "work-list",
-    "message-version": "1.0.0",
-    "message": {
-      "facets": {},
-      "total-results": 49697,
-      "items": [
-        {
-          "DOI": "10.1089/crispr.2020.29108.kda",
-          "title": ["My CRISPR Book"],
-          "container-title": ["The CRISPR Journal"],
-          "published-print": {"date-parts": [[2020, 10, 1]]},
-          "published-online": {"date-parts": [[2020, 10, 20]]}
-        }
-      ],
-      "items-per-page": 1,
-      "query": {
-        "start-index": 0,
-        "search-terms": "CRISPR"
-      }
-    }
-  }
+	"attribution": {
+		"provider": "Crossref",
+		"source_url": "https://api.crossref.org/works?query=CRISPR&rows=1&select=DOI,title,abstract,container-title,published-print,published-online",
+		"retrieved_date": "2026-09-05",
+		"note": "Recorded response reduced only by removing fields outside this capability's contract."
+	},
+	"response": {
+		"status": "ok",
+		"message-type": "work-list",
+		"message-version": "1.0.0",
+		"message": {
+			"facets": {},
+			"total-results": 49697,
+			"items": [
+				{
+					"DOI": "10.1089/crispr.2020.29108.kda",
+					"title": ["My CRISPR Book"],
+					"container-title": ["The CRISPR Journal"],
+					"published-print": { "date-parts": [[2020, 10, 1]] },
+					"published-online": { "date-parts": [[2020, 10, 20]] }
+				}
+			],
+			"items-per-page": 1,
+			"query": {
+				"start-index": 0,
+				"search-terms": "CRISPR"
+			}
+		}
+	}
 }

--- a/tests/fixtures/crossref_crispr.json
+++ b/tests/fixtures/crossref_crispr.json
@@ -1,0 +1,31 @@
+{
+  "attribution": {
+    "provider": "Crossref",
+    "source_url": "https://api.crossref.org/works?query=CRISPR&rows=1&select=DOI,title,abstract,container-title,published-print,published-online",
+    "retrieved_date": "2026-09-05",
+    "note": "Recorded response reduced only by removing fields outside this capability's contract."
+  },
+  "response": {
+    "status": "ok",
+    "message-type": "work-list",
+    "message-version": "1.0.0",
+    "message": {
+      "facets": {},
+      "total-results": 49697,
+      "items": [
+        {
+          "DOI": "10.1089/crispr.2020.29108.kda",
+          "title": ["My CRISPR Book"],
+          "container-title": ["The CRISPR Journal"],
+          "published-print": {"date-parts": [[2020, 10, 1]]},
+          "published-online": {"date-parts": [[2020, 10, 20]]}
+        }
+      ],
+      "items-per-page": 1,
+      "query": {
+        "start-index": 0,
+        "search-terms": "CRISPR"
+      }
+    }
+  }
+}

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -1,0 +1,130 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+from biomni.tool import literature
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload() -> dict:
+    return json.loads((FIXTURES_DIR / "crossref_crispr.json").read_text(encoding="utf-8"))["response"]
+
+
+def test_extract_records_ignores_non_lists():
+    assert literature._extract_crossref_records({}) == []
+    assert literature._extract_crossref_records({"message": {"items": {"DOI": "1"}}}) == []
+
+
+def test_format_record_uses_title_abstract_and_journal():
+    record = {
+        "title": ["Example paper"],
+        "abstract": "<jats:p>Structured abstract text.</jats:p>",
+        "container-title": ["Example Journal"],
+    }
+    output = literature._format_crossref_record(record)
+    assert "Title: Example paper" in output
+    assert "Abstract: Structured abstract text." in output
+    assert "Journal: Example Journal" in output
+
+
+def test_search_crossref_returns_records(monkeypatch):
+    monkeypatch.delenv("CROSSREF_MAILTO", raising=False)
+    session = Mock()
+    session.get.return_value = Response(fixture_payload())
+    records = literature._search_crossref("CRISPR", page_size=1, session=session)
+    assert records[0]["DOI"] == "10.1089/crispr.2020.29108.kda"
+    session.get.assert_called_once()
+
+
+def test_search_crossref_uses_mailto_when_configured(monkeypatch):
+    monkeypatch.setenv("CROSSREF_MAILTO", "test@example.com")
+    session = Mock()
+    session.get.return_value = Response(fixture_payload())
+    literature._search_crossref("CRISPR", page_size=1, session=session)
+    params = session.get.call_args.kwargs["params"]
+    assert params["mailto"] == "test@example.com"
+
+
+def test_query_crossref_returns_formatted_results(monkeypatch):
+    monkeypatch.setattr(
+        literature,
+        "_search_crossref",
+        lambda query, page_size=25: literature._extract_crossref_records(fixture_payload()),
+    )
+    result = literature.query_crossref("CRISPR", max_papers=1, max_retries=0)
+    assert "Title: My CRISPR Book" in result
+    assert "Abstract: No abstract available." in result
+    assert "Journal: The CRISPR Journal" in result
+
+
+def test_query_crossref_retries_with_simplified_query(monkeypatch):
+    queries = []
+
+    def fake_search(query, page_size=25):
+        queries.append(query)
+        if len(queries) == 1:
+            return []
+        return [{"title": ["Paper"], "abstract": "Abstract", "container-title": ["Journal"]}]
+
+    monkeypatch.setattr(literature, "_search_crossref", fake_search)
+    monkeypatch.setattr(literature.time, "sleep", lambda seconds: None)
+    result = literature.query_crossref("single cell atlases", max_papers=1, max_retries=1)
+    assert queries == ["single cell atlases", "single cell"]
+    assert "Title: Paper" in result
+
+
+def test_query_crossref_passes_max_papers_through(monkeypatch):
+    page_sizes = []
+
+    def fake_search(query, page_size=25):
+        page_sizes.append(page_size)
+        return [{"title": ["Paper"], "abstract": "Abstract", "container-title": ["Journal"]}]
+
+    monkeypatch.setattr(literature, "_search_crossref", fake_search)
+    literature.query_crossref("malaria", max_papers=100, max_retries=0)
+    assert page_sizes == [100]
+
+
+def test_query_crossref_returns_no_results_message(monkeypatch):
+    monkeypatch.setattr(literature, "_search_crossref", lambda query, page_size=25: [])
+    result = literature.query_crossref("missing", max_papers=1, max_retries=1)
+    assert result == "No papers found on Crossref after multiple query attempts."
+
+
+def test_query_crossref_returns_error_string_on_http_error(monkeypatch):
+    def fake_search(query, page_size=25):
+        raise requests.HTTPError("429 Client Error")
+
+    monkeypatch.setattr(literature, "_search_crossref", fake_search)
+    result = literature.query_crossref("malaria")
+    assert result == "Error querying Crossref: 429 Client Error"
+
+
+def test_query_crossref_rejects_empty_query():
+    result = literature.query_crossref("   ")
+    assert result == "Error querying Crossref: Query must not be empty."
+
+
+def test_literature_tool_description_exposes_crossref():
+    from biomni.tool.tool_description.literature import description
+
+    names = [tool["name"] for tool in description]
+    assert "query_crossref" in names
+    assert "query_pubmed" in names


### PR DESCRIPTION
## Summary

This PR adds a new A1-visible literature/database tool for Crossref.

Changes:
- adds `query_crossref` to `biomni/tool/literature.py`
- adds the matching tool description entry in `biomni/tool/tool_description/literature.py`
- adds focused fixture-backed tests in `tests/test_crossref.py`
- adds a recorded Crossref fixture in `tests/fixtures/crossref_crispr.json`

`CROSSREF_MAILTO` is supported as an optional environment variable for Crossref polite-pool requests.

## Testing

Focused tests and lint passed:

```bash
pytest /workspace/Biomni/tests/test_semantic_scholar.py /workspace/Biomni/tests/test_crossref.py
ruff check /workspace/Biomni/biomni/tool/literature.py /workspace/Biomni/biomni/tool/tool_description/
literature.py /workspace/Biomni/tests/test_semantic_scholar.py /workspace/Biomni/tests/test_crossref.py

Result:

21 passed, 1 warning
All checks passed!

## Manual Live Validation

Direct live Crossref function smoke passed:

query_crossref('CRISPR', max_papers=1, max_retries=0)

Returned:

Title: My CRISPR Book
Abstract: No abstract available.
Journal: The CRISPR Journal

Manual local-LLM prompt validation also passed against the local OpenAI-compatible Qwen endpoint with A1 tool
retrieval enabled.

Prompt:

"Use only the query_crossref tool to search Crossref for CRISPR. Call query_crossref('CRISPR', max_papers=1,
max_retries=0) exactly once. The tool returns a formatted string, not a list or dict. After you receive the
observation, respond with a <solution> that reports the title, journal, and whether an abstract was returned."

Result:
A1 selected query_crossref, generated an <execute> block, called the live Crossref-backed tool, and returned:

Title: My CRISPR Book
Journal: The CRISPR Journal
Abstract: No abstract was returned.


Crossref API references used:
- https://www.crossref.org/documentation/retrieve-metadata/rest-api/
- https://www.crossref.org/documentation/retrieve-metadata/rest-api/tips-for-using-the-crossref-rest-api/