### PR TITLE
Unpaywall

### DIFF
--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -183,6 +183,73 @@ def query_pubmed(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
         return f"Error querying PubMed: {e}"
 
 
+def _format_unpaywall_record(record: dict) -> str:
+    title = record.get("title") or "N/A"
+    doi = record.get("doi") or "N/A"
+    journal = record.get("journal_name") or "N/A"
+    is_oa = record.get("is_oa")
+    open_access = "Yes" if is_oa is True else "No" if is_oa is False else "N/A"
+    oa_status = record.get("oa_status") or "N/A"
+    best_location = record.get("best_oa_location") or {}
+    best_oa_url = best_location.get("url_for_pdf") or best_location.get("url_for_landing_page") or "N/A"
+    license_name = best_location.get("license") or "N/A"
+    return (
+        f"Title: {title}\n"
+        f"DOI: {doi}\n"
+        f"Journal: {journal}\n"
+        f"Open Access: {open_access}\n"
+        f"OA Status: {oa_status}\n"
+        f"Best OA URL: {best_oa_url}\n"
+        f"License: {license_name}"
+    )
+
+
+def _search_unpaywall(doi: str, email: str, session: requests.Session | None = None) -> dict:
+    active_session = session or requests.Session()
+    response = active_session.get(
+        f"https://api.unpaywall.org/v2/{doi}",
+        params={"email": email},
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def query_unpaywall(doi: str, email: str | None = None) -> str:
+    """Query Unpaywall for open-access status and full-text locations for a DOI.
+
+    Parameters
+    ----------
+    - doi (str): The paper DOI.
+    - email (str): Contact email required by the Unpaywall API. Uses UNPAYWALL_EMAIL if omitted.
+
+    Returns
+    -------
+    - str: The formatted open-access result or an error message.
+
+    """
+    try:
+        search_doi = doi.strip()
+        if not search_doi:
+            return "Error querying Unpaywall: DOI must not be empty."
+
+        contact_email = email or os.getenv("UNPAYWALL_EMAIL")
+        if not contact_email:
+            return "Error querying Unpaywall: Set UNPAYWALL_EMAIL or pass email."
+
+        record = _search_unpaywall(search_doi, contact_email)
+        if record:
+            return _format_unpaywall_record(record)
+        return "No record found on Unpaywall."
+    except requests.RequestException as e:
+        return f"Error querying Unpaywall: {e}"
+    except ValueError as e:
+        return f"Error querying Unpaywall: {e}"
+
+
 def search_google(query: str, num_results: int = 3, language: str = "en") -> list[dict]:
     """Search using Google search.
 

--- a/biomni/tool/tool_description/literature.py
+++ b/biomni/tool/tool_description/literature.py
@@ -1,5 +1,25 @@
 description = [
     {
+        "description": "Query Unpaywall for open-access status and full-text locations for a DOI.",
+        "name": "query_unpaywall",
+        "optional_parameters": [
+            {
+                "default": None,
+                "description": "Contact email required by the Unpaywall API. Uses UNPAYWALL_EMAIL if omitted.",
+                "name": "email",
+                "type": "str",
+            }
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The paper DOI.",
+                "name": "doi",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Fetches supplementary information for a paper given its DOI "
         "and saves it to a specified directory.",
         "name": "fetch_supplementary_info_from_doi",

--- a/tests/fixtures/unpaywall_bioconductor.json
+++ b/tests/fixtures/unpaywall_bioconductor.json
@@ -1,33 +1,33 @@
 {
-  "attribution": {
-    "provider": "Unpaywall",
-    "source_url": "https://raw.githubusercontent.com/ourresearch/unpaywall-website/master/api_responses.md",
-    "retrieved_date": "2026-09-06",
-    "note": "Public Unpaywall API response example reduced only by removing fields outside this capability's contract."
-  },
-  "response": {
-    "doi": "10.1186/gb-2004-5-10-r80",
-    "doi_url": "https://doi.org/10.1186/gb-2004-5-10-r80",
-    "title": "Bioconductor: open software development for computational biology and bioinformatics",
-    "genre": "journal-article",
-    "published_date": "2004-09-15",
-    "year": 2004,
-    "journal_name": "Genome Biology",
-    "publisher": "Springer Science and Business Media LLC",
-    "is_oa": true,
-    "oa_status": "gold",
-    "has_repository_copy": true,
-    "best_oa_location": {
-      "url": "https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80",
-      "url_for_pdf": "https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80",
-      "url_for_landing_page": "https://doi.org/10.1186/gb-2004-5-10-r80",
-      "evidence": "oa journal (via doaj)",
-      "license": "cc-by",
-      "version": "publishedVersion",
-      "host_type": "publisher",
-      "is_best": true,
-      "oa_date": "2004-09-15"
-    },
-    "data_standard": 2
-  }
+	"attribution": {
+		"provider": "Unpaywall",
+		"source_url": "https://raw.githubusercontent.com/ourresearch/unpaywall-website/master/api_responses.md",
+		"retrieved_date": "2026-09-06",
+		"note": "Public Unpaywall API response example reduced only by removing fields outside this capability's contract."
+	},
+	"response": {
+		"doi": "10.1186/gb-2004-5-10-r80",
+		"doi_url": "https://doi.org/10.1186/gb-2004-5-10-r80",
+		"title": "Bioconductor: open software development for computational biology and bioinformatics",
+		"genre": "journal-article",
+		"published_date": "2004-09-15",
+		"year": 2004,
+		"journal_name": "Genome Biology",
+		"publisher": "Springer Science and Business Media LLC",
+		"is_oa": true,
+		"oa_status": "gold",
+		"has_repository_copy": true,
+		"best_oa_location": {
+			"url": "https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80",
+			"url_for_pdf": "https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80",
+			"url_for_landing_page": "https://doi.org/10.1186/gb-2004-5-10-r80",
+			"evidence": "oa journal (via doaj)",
+			"license": "cc-by",
+			"version": "publishedVersion",
+			"host_type": "publisher",
+			"is_best": true,
+			"oa_date": "2004-09-15"
+		},
+		"data_standard": 2
+	}
 }

--- a/tests/fixtures/unpaywall_bioconductor.json
+++ b/tests/fixtures/unpaywall_bioconductor.json
@@ -1,0 +1,33 @@
+{
+  "attribution": {
+    "provider": "Unpaywall",
+    "source_url": "https://raw.githubusercontent.com/ourresearch/unpaywall-website/master/api_responses.md",
+    "retrieved_date": "2026-09-06",
+    "note": "Public Unpaywall API response example reduced only by removing fields outside this capability's contract."
+  },
+  "response": {
+    "doi": "10.1186/gb-2004-5-10-r80",
+    "doi_url": "https://doi.org/10.1186/gb-2004-5-10-r80",
+    "title": "Bioconductor: open software development for computational biology and bioinformatics",
+    "genre": "journal-article",
+    "published_date": "2004-09-15",
+    "year": 2004,
+    "journal_name": "Genome Biology",
+    "publisher": "Springer Science and Business Media LLC",
+    "is_oa": true,
+    "oa_status": "gold",
+    "has_repository_copy": true,
+    "best_oa_location": {
+      "url": "https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80",
+      "url_for_pdf": "https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80",
+      "url_for_landing_page": "https://doi.org/10.1186/gb-2004-5-10-r80",
+      "evidence": "oa journal (via doaj)",
+      "license": "cc-by",
+      "version": "publishedVersion",
+      "host_type": "publisher",
+      "is_best": true,
+      "oa_date": "2004-09-15"
+    },
+    "data_standard": 2
+  }
+}

--- a/tests/test_unpaywall.py
+++ b/tests/test_unpaywall.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+from biomni.tool import literature
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload() -> dict:
+    return json.loads((FIXTURES_DIR / "unpaywall_bioconductor.json").read_text(encoding="utf-8"))["response"]
+
+
+def test_format_record_uses_open_access_fields():
+    record = {
+        "doi": "10.1186/gb-2004-5-10-r80",
+        "title": "Bioconductor: open software development for computational biology and bioinformatics",
+        "journal_name": "Genome Biology",
+        "is_oa": True,
+        "oa_status": "gold",
+        "best_oa_location": {
+            "url_for_pdf": "https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80",
+            "license": "cc-by",
+        },
+    }
+    output = literature._format_unpaywall_record(record)
+    assert "Title: Bioconductor: open software development" in output
+    assert "DOI: 10.1186/gb-2004-5-10-r80" in output
+    assert "Journal: Genome Biology" in output
+    assert "Open Access: Yes" in output
+    assert "OA Status: gold" in output
+    assert "Best OA URL: https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80" in output
+    assert "License: cc-by" in output
+
+
+def test_search_unpaywall_returns_record():
+    session = Mock()
+    session.get.return_value = Response(fixture_payload())
+    record = literature._search_unpaywall("10.1186/gb-2004-5-10-r80", "test@example.org", session=session)
+    assert record["doi"] == "10.1186/gb-2004-5-10-r80"
+    session.get.assert_called_once()
+
+
+def test_query_unpaywall_returns_formatted_result(monkeypatch):
+    monkeypatch.setattr(literature, "_search_unpaywall", lambda doi, email: fixture_payload())
+    result = literature.query_unpaywall("10.1186/gb-2004-5-10-r80", email="test@example.org")
+    assert "Title: Bioconductor: open software development" in result
+    assert "Open Access: Yes" in result
+    assert "OA Status: gold" in result
+    assert "License: cc-by" in result
+
+
+def test_query_unpaywall_uses_env_email(monkeypatch):
+    calls = []
+
+    def fake_search(doi, email):
+        calls.append((doi, email))
+        return fixture_payload()
+
+    monkeypatch.setenv("UNPAYWALL_EMAIL", "test@example.org")
+    monkeypatch.setattr(literature, "_search_unpaywall", fake_search)
+    literature.query_unpaywall("10.1186/gb-2004-5-10-r80")
+    assert calls == [("10.1186/gb-2004-5-10-r80", "test@example.org")]
+
+
+def test_query_unpaywall_requires_email(monkeypatch):
+    monkeypatch.delenv("UNPAYWALL_EMAIL", raising=False)
+    result = literature.query_unpaywall("10.1186/gb-2004-5-10-r80")
+    assert result == "Error querying Unpaywall: Set UNPAYWALL_EMAIL or pass email."
+
+
+def test_query_unpaywall_rejects_empty_doi():
+    result = literature.query_unpaywall("   ", email="test@example.org")
+    assert result == "Error querying Unpaywall: DOI must not be empty."
+
+
+def test_query_unpaywall_returns_no_record_message(monkeypatch):
+    monkeypatch.setattr(literature, "_search_unpaywall", lambda doi, email: {})
+    result = literature.query_unpaywall("10.1234/missing", email="test@example.org")
+    assert result == "No record found on Unpaywall."
+
+
+def test_query_unpaywall_returns_error_string_on_http_error(monkeypatch):
+    def fake_search(doi, email):
+        raise requests.HTTPError("404 Client Error")
+
+    monkeypatch.setattr(literature, "_search_unpaywall", fake_search)
+    result = literature.query_unpaywall("10.1234/missing", email="test@example.org")
+    assert result == "Error querying Unpaywall: 404 Client Error"
+
+
+def test_literature_tool_description_exposes_unpaywall():
+    from biomni.tool.tool_description.literature import description
+
+    names = [tool["name"] for tool in description]
+    assert "query_unpaywall" in names
+    assert "query_pubmed" in names


### PR DESCRIPTION
## Summary

  This PR adds a new A1-visible literature/database tool for Unpaywall DOI open-access lookup.

  Changes:

  - adds query_unpaywall to biomni/tool/literature.py
  - adds the matching tool description entry in biomni/tool/tool_description/literature.py
  - adds focused fixture-backed tests in tests/test_unpaywall.py
  - adds a reduced public Unpaywall fixture in tests/fixtures/unpaywall_bioconductor.json

  query_unpaywall accepts a DOI and uses either an explicit email argument or the UNPAYWALL_EMAIL environment variable, matching
  Unpaywall’s API requirement for a contact email.

  ## Testing

  Focused tests and lint passed:

  pytest /workspace/Biomni/tests/test_crossref.py /workspace/Biomni/tests/test_unpaywall.py
  ruff check /workspace/Biomni/biomni/tool/literature.py /workspace/Biomni/biomni/tool/tool_description/literature.py /workspace/
  Biomni/tests/test_crossref.py /workspace/Biomni/tests/test_unpaywall.py

  Result:

  20 passed, 1 warning
  All checks passed!

  ## Manual Live Prompt Validation

  Manual local-LLM prompt validation passed against the local OpenAI-compatible Qwen endpoint with A1 tool retrieval enabled.

  Prompt:

  Use only the query_unpaywall tool to check the Unpaywall open-access status for DOI 10.1186/gb-2004-5-10-r80. Call
  query_unpaywall('10.1186/gb-2004-5-10-r80') exactly once. The tool returns a formatted string or an error string. After you receive
  the observation, respond with a <solution> that reports the title, open-access status, best OA URL, and license if returned. If the
  observation is an error, report the exact error in the <solution>.

  Result:

  - A1 selected query_unpaywall
  - A1 generated an <execute> block
  - The tool queried live Unpaywall using UNPAYWALL_EMAIL
  - A1 completed with a <solution>

  Observed tool output:

  Title: Bioconductor: open software development for computational biology and bioinformatics
  DOI: 10.1186/gb-2004-5-10-r80
  Journal: Genome biology
  Open Access: Yes
  OA Status: gold
  Best OA URL: https://genomebiology.biomedcentral.com/counter/pdf/10.1186/gb-2004-5-10-r80
  License: cc-by

  ## Notes

  Unpaywall requires a real contact email. This PR supports either:

  - passing email= directly to query_unpaywall
  - setting UNPAYWALL_EMAIL in the environment

  The live prompt test used UNPAYWALL_EMAIL from the local environment.