### PR TITLE
Add Semantic Scholar literature tool

### DIFF
--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -183,6 +183,87 @@ def query_pubmed(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
         return f"Error querying PubMed: {e}"
 
 
+def _extract_semantic_scholar_records(payload: dict) -> list[dict]:
+    data = payload.get("data", [])
+    if isinstance(data, list):
+        return [record for record in data if isinstance(record, dict)]
+    return []
+
+
+def _simplify_semantic_scholar_query(query: str, retry_index: int) -> str:
+    parts = query.split()
+    if len(parts) > retry_index:
+        return " ".join(parts[:-retry_index])
+    return query
+
+
+def _format_semantic_scholar_record(record: dict) -> str:
+    title = record.get("title") or "N/A"
+    abstract = record.get("abstract") or "No abstract available."
+    journal = record.get("venue") or "N/A"
+    return f"Title: {title}\nAbstract: {abstract}\nJournal: {journal}"
+
+
+def _search_semantic_scholar(query: str, page_size: int = 25, session: requests.Session | None = None) -> list[dict]:
+    active_session = session or requests.Session()
+    headers = {}
+    api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY")
+    if api_key:
+        headers["x-api-key"] = api_key
+
+    response = active_session.get(
+        "https://api.semanticscholar.org/graph/v1/paper/search",
+        params={
+            "query": query,
+            "limit": page_size,
+            "fields": "title,abstract,venue",
+        },
+        headers=headers,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return _extract_semantic_scholar_records(response.json())
+
+
+def query_semantic_scholar(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
+    """Query Semantic Scholar for papers based on the provided search query.
+
+    Parameters
+    ----------
+    - query (str): The search query string.
+    - max_papers (int): The maximum number of papers to retrieve (default: 10).
+    - max_retries (int): Maximum number of retry attempts with modified queries (default: 3).
+
+    Returns
+    -------
+    - str: The formatted search results or an error message.
+
+    """
+    try:
+        search_query = query.strip()
+        if not search_query:
+            return "Error querying Semantic Scholar: Query must not be empty."
+
+        page_size = max(1, int(max_papers))
+        retries = max(0, int(max_retries))
+        records = _search_semantic_scholar(search_query, page_size=page_size)
+
+        retry_count = 0
+        while not records and retry_count < retries:
+            retry_count += 1
+            search_query = _simplify_semantic_scholar_query(search_query, retry_count)
+            time.sleep(1)
+            records = _search_semantic_scholar(search_query, page_size=page_size)
+
+        if records:
+            return "\n\n".join(_format_semantic_scholar_record(record) for record in records[:page_size])
+        return "No papers found on Semantic Scholar after multiple query attempts."
+    except requests.RequestException as e:
+        return f"Error querying Semantic Scholar: {e}"
+    except ValueError as e:
+        return f"Error querying Semantic Scholar: {e}"
+
+
 def search_google(query: str, num_results: int = 3, language: str = "en") -> list[dict]:
     """Search using Google search.
 

--- a/biomni/tool/tool_description/literature.py
+++ b/biomni/tool/tool_description/literature.py
@@ -1,5 +1,31 @@
 description = [
     {
+        "description": "Query Semantic Scholar for papers based on the provided search query.",
+        "name": "query_semantic_scholar",
+        "optional_parameters": [
+            {
+                "default": 10,
+                "description": "The maximum number of papers to retrieve.",
+                "name": "max_papers",
+                "type": "int",
+            },
+            {
+                "default": 3,
+                "description": "Maximum number of retry attempts with modified queries.",
+                "name": "max_retries",
+                "type": "int",
+            },
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The search query string.",
+                "name": "query",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Fetches supplementary information for a paper given its DOI "
         "and saves it to a specified directory.",
         "name": "fetch_supplementary_info_from_doi",

--- a/tests/fixtures/semantic_scholar_crispr.json
+++ b/tests/fixtures/semantic_scholar_crispr.json
@@ -1,22 +1,22 @@
 {
-  "attribution": {
-    "provider": "Semantic Scholar",
-    "source_url": "https://api.semanticscholar.org/graph/v1/paper/search?query=CRISPR&limit=1&fields=title,abstract,venue,year",
-    "retrieved_date": "2026-09-05",
-    "note": "Recorded response reduced only by removing fields outside this capability's contract."
-  },
-  "response": {
-    "total": 98434,
-    "offset": 0,
-    "next": 1,
-    "data": [
-      {
-        "paperId": "b9e5fa707e804d6008e5011b058244437c656a93",
-        "title": "Optimized sgRNA design to maximize activity and minimize off-target effects of CRISPR-Cas9",
-        "venue": "Nature Biotechnology",
-        "year": 2016,
-        "abstract": "CRISPR-Cas9\\u2013based genetic screens are a powerful new tool in biology. By simply altering the sequence of the single-guide RNA (sgRNA), one can reprogram Cas9 to target different sites in the genome with relative ease, but the on-target activity and off-target effects of individual sgRNAs can vary widely. Here, we use recently devised sgRNA design rules to create human and mouse genome-wide libraries, perform positive and negative selection screens and observe that the use of these rules produced improved results. Additionally, we profile the off-target activity of thousands of sgRNAs and develop a metric to predict off-target sites. We incorporate these findings from large-scale, empirical data to improve our computational design rules and create optimized sgRNA libraries that maximize on-target activity and minimize off-target effects to enable more effective and efficient genetic screens and genome engineering."
-      }
-    ]
-  }
+	"attribution": {
+		"provider": "Semantic Scholar",
+		"source_url": "https://api.semanticscholar.org/graph/v1/paper/search?query=CRISPR&limit=1&fields=title,abstract,venue,year",
+		"retrieved_date": "2026-09-05",
+		"note": "Recorded response reduced only by removing fields outside this capability's contract."
+	},
+	"response": {
+		"total": 98434,
+		"offset": 0,
+		"next": 1,
+		"data": [
+			{
+				"paperId": "b9e5fa707e804d6008e5011b058244437c656a93",
+				"title": "Optimized sgRNA design to maximize activity and minimize off-target effects of CRISPR-Cas9",
+				"venue": "Nature Biotechnology",
+				"year": 2016,
+				"abstract": "CRISPR-Cas9\\u2013based genetic screens are a powerful new tool in biology. By simply altering the sequence of the single-guide RNA (sgRNA), one can reprogram Cas9 to target different sites in the genome with relative ease, but the on-target activity and off-target effects of individual sgRNAs can vary widely. Here, we use recently devised sgRNA design rules to create human and mouse genome-wide libraries, perform positive and negative selection screens and observe that the use of these rules produced improved results. Additionally, we profile the off-target activity of thousands of sgRNAs and develop a metric to predict off-target sites. We incorporate these findings from large-scale, empirical data to improve our computational design rules and create optimized sgRNA libraries that maximize on-target activity and minimize off-target effects to enable more effective and efficient genetic screens and genome engineering."
+			}
+		]
+	}
 }

--- a/tests/fixtures/semantic_scholar_crispr.json
+++ b/tests/fixtures/semantic_scholar_crispr.json
@@ -1,0 +1,22 @@
+{
+  "attribution": {
+    "provider": "Semantic Scholar",
+    "source_url": "https://api.semanticscholar.org/graph/v1/paper/search?query=CRISPR&limit=1&fields=title,abstract,venue,year",
+    "retrieved_date": "2026-09-05",
+    "note": "Recorded response reduced only by removing fields outside this capability's contract."
+  },
+  "response": {
+    "total": 98434,
+    "offset": 0,
+    "next": 1,
+    "data": [
+      {
+        "paperId": "b9e5fa707e804d6008e5011b058244437c656a93",
+        "title": "Optimized sgRNA design to maximize activity and minimize off-target effects of CRISPR-Cas9",
+        "venue": "Nature Biotechnology",
+        "year": 2016,
+        "abstract": "CRISPR-Cas9\\u2013based genetic screens are a powerful new tool in biology. By simply altering the sequence of the single-guide RNA (sgRNA), one can reprogram Cas9 to target different sites in the genome with relative ease, but the on-target activity and off-target effects of individual sgRNAs can vary widely. Here, we use recently devised sgRNA design rules to create human and mouse genome-wide libraries, perform positive and negative selection screens and observe that the use of these rules produced improved results. Additionally, we profile the off-target activity of thousands of sgRNAs and develop a metric to predict off-target sites. We incorporate these findings from large-scale, empirical data to improve our computational design rules and create optimized sgRNA libraries that maximize on-target activity and minimize off-target effects to enable more effective and efficient genetic screens and genome engineering."
+      }
+    ]
+  }
+}

--- a/tests/test_semantic_scholar.py
+++ b/tests/test_semantic_scholar.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+from biomni.tool import literature
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload() -> dict:
+    return json.loads((FIXTURES_DIR / "semantic_scholar_crispr.json").read_text(encoding="utf-8"))["response"]
+
+
+def test_extract_records_ignores_non_lists():
+    assert literature._extract_semantic_scholar_records({}) == []
+    assert literature._extract_semantic_scholar_records({"data": {"paperId": "1"}}) == []
+
+
+def test_format_record_uses_abstract_and_journal():
+    record = {
+        "title": "Optimized sgRNA design to maximize activity and minimize off-target effects of CRISPR-Cas9",
+        "abstract": "CRISPR-Cas9 screens are a powerful tool.",
+        "venue": "Nature Biotechnology",
+    }
+    output = literature._format_semantic_scholar_record(record)
+    assert "Title: Optimized sgRNA design" in output
+    assert "Abstract: CRISPR-Cas9 screens are a powerful tool." in output
+    assert "Journal: Nature Biotechnology" in output
+
+
+def test_search_semantic_scholar_returns_records():
+    session = Mock()
+    session.get.return_value = Response(fixture_payload())
+    records = literature._search_semantic_scholar("CRISPR", page_size=1, session=session)
+    assert records[0]["paperId"] == "b9e5fa707e804d6008e5011b058244437c656a93"
+    session.get.assert_called_once()
+
+
+def test_query_semantic_scholar_returns_formatted_results(monkeypatch):
+    monkeypatch.setattr(
+        literature,
+        "_search_semantic_scholar",
+        lambda query, page_size=25: literature._extract_semantic_scholar_records(fixture_payload()),
+    )
+    result = literature.query_semantic_scholar("CRISPR", max_papers=1, max_retries=0)
+    assert "Title: Optimized sgRNA design to maximize activity" in result
+    assert "Abstract: CRISPR-Cas9" in result
+    assert "Journal: Nature Biotechnology" in result
+
+
+def test_query_semantic_scholar_retries_with_simplified_query(monkeypatch):
+    queries = []
+
+    def fake_search(query, page_size=25):
+        queries.append(query)
+        if len(queries) == 1:
+            return []
+        return [{"title": "Paper", "abstract": "Abstract", "venue": "Journal"}]
+
+    monkeypatch.setattr(literature, "_search_semantic_scholar", fake_search)
+    monkeypatch.setattr(literature.time, "sleep", lambda seconds: None)
+    result = literature.query_semantic_scholar("single cell atlases", max_papers=1, max_retries=1)
+    assert queries == ["single cell atlases", "single cell"]
+    assert "Title: Paper" in result
+
+
+def test_query_semantic_scholar_passes_max_papers_through(monkeypatch):
+    page_sizes = []
+
+    def fake_search(query, page_size=25):
+        page_sizes.append(page_size)
+        return [{"title": "Paper", "abstract": "Abstract", "venue": "Journal"}]
+
+    monkeypatch.setattr(literature, "_search_semantic_scholar", fake_search)
+    literature.query_semantic_scholar("malaria", max_papers=100, max_retries=0)
+    assert page_sizes == [100]
+
+
+def test_query_semantic_scholar_returns_no_results_message(monkeypatch):
+    monkeypatch.setattr(literature, "_search_semantic_scholar", lambda query, page_size=25: [])
+    result = literature.query_semantic_scholar("missing", max_papers=1, max_retries=1)
+    assert result == "No papers found on Semantic Scholar after multiple query attempts."
+
+
+def test_query_semantic_scholar_returns_error_string_on_http_error(monkeypatch):
+    def fake_search(query, page_size=25):
+        raise requests.HTTPError("429 Client Error")
+
+    monkeypatch.setattr(literature, "_search_semantic_scholar", fake_search)
+    result = literature.query_semantic_scholar("malaria")
+    assert result == "Error querying Semantic Scholar: 429 Client Error"
+
+
+def test_query_semantic_scholar_rejects_empty_query():
+    result = literature.query_semantic_scholar("   ")
+    assert result == "Error querying Semantic Scholar: Query must not be empty."
+
+
+def test_literature_tool_description_exposes_semantic_scholar():
+    from biomni.tool.tool_description.literature import description
+
+    names = [tool["name"] for tool in description]
+    assert "query_semantic_scholar" in names
+    assert "query_pubmed" in names


### PR DESCRIPTION
This PR adds a new A1-visible literature/database tool for Semantic Scholar paper search.

Changes:

adds `query_semantic_scholar` to `biomni/tool/literature.py`
adds the matching tool description entry in `biomni/tool/tool_description/literature.py`
adds focused fixture-backed tests in `tests/test_semantic_scholar.py`
adds a reduced public Semantic Scholar-style fixture in `tests/fixtures/semantic_scholar_crispr.json`

`query_semantic_scholar` accepts a search query, optional `max_papers`, and optional `max_retries`. It uses the Semantic Scholar Graph API paper search endpoint and supports `SEMANTIC_SCHOLAR_API_KEY` when available.

Testing
Focused tests and lint passed:

```bash
python -m pytest tests/test_semantic_scholar.py
python -m ruff check biomni/tool/literature.py biomni/tool/tool_description/literature.py tests/test_semantic_scholar.py
```

Result:

```text
10 passed, 1 warning
All checks passed!
```

Manual Live Prompt Validation
A1 local prompt validation reached the new tool path, but the live anonymous Semantic Scholar API request returned HTTP 429 rate limiting in this environment. The implementation supports authenticated requests through `SEMANTIC_SCHOLAR_API_KEY`.

Notes
This follows the existing legacy literature-tool pattern: the implementation is added directly to `biomni/tool/literature.py`, the A1-visible description is added directly to `biomni/tool/tool_description/literature.py`, and tests use a local fixture with a mocked response.