### PR TITLE
Add bioRxiv/medRxiv literature tool

### DIFF
--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -1,6 +1,7 @@
 import os
 import re
 import time
+from datetime import date, timedelta
 from io import BytesIO
 from urllib.parse import urljoin
 
@@ -181,6 +182,145 @@ def query_pubmed(query: str, max_papers: int = 10, max_retries: int = 3) -> str:
             return "No papers found on PubMed after multiple query attempts."
     except Exception as e:
         return f"Error querying PubMed: {e}"
+
+
+def _extract_biorxiv_medrxiv_records(payload: dict) -> list[dict]:
+    collection = payload.get("collection", [])
+    if isinstance(collection, list):
+        return [record for record in collection if isinstance(record, dict)]
+    return []
+
+
+def _get_biorxiv_medrxiv_total(payload: dict) -> int | None:
+    messages = payload.get("messages", [])
+    if isinstance(messages, list) and messages:
+        try:
+            return int(messages[0].get("total"))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _format_biorxiv_medrxiv_record(record: dict) -> str:
+    title = record.get("title") or "N/A"
+    abstract = record.get("abstract") or "No abstract available."
+    journal = record.get("server") or record.get("journal") or "N/A"
+    doi = record.get("doi") or "N/A"
+    posted = record.get("date") or "N/A"
+    category = record.get("category") or "N/A"
+    url = record.get("jatsxml") or record.get("link") or (f"https://doi.org/{doi}" if doi != "N/A" else "N/A")
+    return (
+        f"Title: {title}\n"
+        f"Abstract: {abstract}\n"
+        f"Journal: {journal}\n"
+        f"DOI: {doi}\n"
+        f"Posted: {posted}\n"
+        f"Category: {category}\n"
+        f"URL: {url}"
+    )
+
+
+def _biorxiv_medrxiv_record_matches(record: dict, terms: list[str], category: str) -> bool:
+    if category != "all" and (record.get("category") or "").lower() != category:
+        return False
+    if not terms:
+        return True
+    text = " ".join(
+        str(record.get(field) or "")
+        for field in ("title", "abstract", "authors", "category", "doi")
+    ).lower()
+    return all(term in text for term in terms)
+
+
+def _search_biorxiv_medrxiv(
+    query: str,
+    server: str = "biorxiv",
+    max_papers: int = 10,
+    days_back: int = 30,
+    category: str = "all",
+    session: requests.Session | None = None,
+) -> list[dict]:
+    active_session = session or requests.Session()
+    today = date.today()
+    start_date = today - timedelta(days=max(1, int(days_back)))
+    interval = f"{start_date.isoformat()}/{today.isoformat()}"
+    cursor = 0
+    results = []
+    terms = [term.lower() for term in query.split() if term.strip()]
+    normalized_category = category.strip().lower() or "all"
+
+    while len(results) < max_papers:
+        response = active_session.get(
+            f"https://api.biorxiv.org/details/{server}/{interval}/{cursor}/json",
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        records = _extract_biorxiv_medrxiv_records(payload)
+        if not records:
+            break
+        total = _get_biorxiv_medrxiv_total(payload)
+
+        for record in records:
+            if _biorxiv_medrxiv_record_matches(record, terms, normalized_category):
+                results.append(record)
+                if len(results) >= max_papers:
+                    break
+
+        cursor += len(records)
+        if total is not None and cursor >= total:
+            break
+
+    return results
+
+
+def query_biorxiv_medrxiv(
+    query: str,
+    max_papers: int = 10,
+    server: str = "biorxiv",
+    days_back: int = 30,
+    category: str = "all",
+) -> str:
+    """Query bioRxiv or medRxiv for recent preprints based on the provided search query.
+
+    Parameters
+    ----------
+    - query (str): The search query string.
+    - max_papers (int): The maximum number of papers to retrieve (default: 10).
+    - server (str): The preprint server to query, either "biorxiv" or "medrxiv" (default: "biorxiv").
+    - days_back (int): Number of recent days to search (default: 30).
+    - category (str): Optional category filter, or "all" (default: "all").
+
+    Returns
+    -------
+    - str: The formatted search results or an error message.
+
+    """
+    try:
+        search_query = query.strip()
+        if not search_query:
+            return "Error querying bioRxiv/medRxiv: Query must not be empty."
+
+        normalized_server = server.strip().lower()
+        if normalized_server not in {"biorxiv", "medrxiv"}:
+            return 'Error querying bioRxiv/medRxiv: Server must be "biorxiv" or "medrxiv".'
+
+        page_size = max(1, int(max_papers))
+        records = _search_biorxiv_medrxiv(
+            search_query,
+            server=normalized_server,
+            max_papers=page_size,
+            days_back=days_back,
+            category=category,
+        )
+
+        if records:
+            return "\n\n".join(_format_biorxiv_medrxiv_record(record) for record in records[:page_size])
+        return "No preprints found on bioRxiv/medRxiv."
+    except requests.RequestException as e:
+        return f"Error querying bioRxiv/medRxiv: {e}"
+    except ValueError as e:
+        return f"Error querying bioRxiv/medRxiv: {e}"
 
 
 def search_google(query: str, num_results: int = 3, language: str = "en") -> list[dict]:

--- a/biomni/tool/literature.py
+++ b/biomni/tool/literature.py
@@ -226,8 +226,7 @@ def _biorxiv_medrxiv_record_matches(record: dict, terms: list[str], category: st
     if not terms:
         return True
     text = " ".join(
-        str(record.get(field) or "")
-        for field in ("title", "abstract", "authors", "category", "doi")
+        str(record.get(field) or "") for field in ("title", "abstract", "authors", "category", "doi")
     ).lower()
     return all(term in text for term in terms)
 

--- a/biomni/tool/tool_description/literature.py
+++ b/biomni/tool/tool_description/literature.py
@@ -1,5 +1,43 @@
 description = [
     {
+        "description": "Query bioRxiv or medRxiv for recent preprints based on the provided search query.",
+        "name": "query_biorxiv_medrxiv",
+        "optional_parameters": [
+            {
+                "default": 10,
+                "description": "The maximum number of papers to retrieve.",
+                "name": "max_papers",
+                "type": "int",
+            },
+            {
+                "default": "biorxiv",
+                "description": 'The preprint server to query, either "biorxiv" or "medrxiv".',
+                "name": "server",
+                "type": "str",
+            },
+            {
+                "default": 30,
+                "description": "Number of recent days to search.",
+                "name": "days_back",
+                "type": "int",
+            },
+            {
+                "default": "all",
+                "description": 'Optional category filter, or "all".',
+                "name": "category",
+                "type": "str",
+            },
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The search query string.",
+                "name": "query",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Fetches supplementary information for a paper given its DOI "
         "and saves it to a specified directory.",
         "name": "fetch_supplementary_info_from_doi",

--- a/tests/fixtures/biorxiv_zebrafish.json
+++ b/tests/fixtures/biorxiv_zebrafish.json
@@ -1,38 +1,38 @@
 {
-  "attribution": {
-    "provider": "bioRxiv",
-    "source_url": "https://api.biorxiv.org/details/biorxiv/2026-09-01/2026-09-08/0/json",
-    "retrieved_date": "2026-09-08",
-    "note": "Public bioRxiv API response example reduced to one record."
-  },
-  "response": {
-    "messages": [
-      {
-        "status": "ok",
-        "category": "all",
-        "interval": "2026-09-01:2026-09-08",
-        "funder": "all",
-        "cursor": 0,
-        "count": 1,
-        "count_new_papers": "1066",
-        "total": "1478"
-      }
-    ],
-    "collection": [
-      {
-        "title": "Zebrafish larval nitrogen excretion is flexible and resilient to loss of rhesus glycoproteins",
-        "authors": "Mes, W.; Haanen, R.; Arshad, A.; Klaren, P. H. M.; Schaaf, M. J. M.; Faught, E.; Nakada, T.; van Kessel, M. A. H. J.; Gorissen, M.",
-        "doi": "10.64898/2026.08.28.747819",
-        "date": "2026-09-01",
-        "version": "1",
-        "type": "new results",
-        "license": "cc_by_nc_nd",
-        "category": "physiology",
-        "jatsxml": "https://www.biorxiv.org/content/early/2026/09/01/2026.08.28.747819.source.xml",
-        "abstract": "Nitrogenous waste excretion is essential for all developmental stages of fish. In zebrafish, ammonia excretion involves rhesus glycoproteins Rhbg and Rhcgb.",
-        "published": "NA",
-        "server": "bioRxiv"
-      }
-    ]
-  }
+	"attribution": {
+		"provider": "bioRxiv",
+		"source_url": "https://api.biorxiv.org/details/biorxiv/2026-09-01/2026-09-08/0/json",
+		"retrieved_date": "2026-09-08",
+		"note": "Public bioRxiv API response example reduced to one record."
+	},
+	"response": {
+		"messages": [
+			{
+				"status": "ok",
+				"category": "all",
+				"interval": "2026-09-01:2026-09-08",
+				"funder": "all",
+				"cursor": 0,
+				"count": 1,
+				"count_new_papers": "1066",
+				"total": "1478"
+			}
+		],
+		"collection": [
+			{
+				"title": "Zebrafish larval nitrogen excretion is flexible and resilient to loss of rhesus glycoproteins",
+				"authors": "Mes, W.; Haanen, R.; Arshad, A.; Klaren, P. H. M.; Schaaf, M. J. M.; Faught, E.; Nakada, T.; van Kessel, M. A. H. J.; Gorissen, M.",
+				"doi": "10.64898/2026.08.28.747819",
+				"date": "2026-09-01",
+				"version": "1",
+				"type": "new results",
+				"license": "cc_by_nc_nd",
+				"category": "physiology",
+				"jatsxml": "https://www.biorxiv.org/content/early/2026/09/01/2026.08.28.747819.source.xml",
+				"abstract": "Nitrogenous waste excretion is essential for all developmental stages of fish. In zebrafish, ammonia excretion involves rhesus glycoproteins Rhbg and Rhcgb.",
+				"published": "NA",
+				"server": "bioRxiv"
+			}
+		]
+	}
 }

--- a/tests/fixtures/biorxiv_zebrafish.json
+++ b/tests/fixtures/biorxiv_zebrafish.json
@@ -1,0 +1,38 @@
+{
+  "attribution": {
+    "provider": "bioRxiv",
+    "source_url": "https://api.biorxiv.org/details/biorxiv/2026-09-01/2026-09-08/0/json",
+    "retrieved_date": "2026-09-08",
+    "note": "Public bioRxiv API response example reduced to one record."
+  },
+  "response": {
+    "messages": [
+      {
+        "status": "ok",
+        "category": "all",
+        "interval": "2026-09-01:2026-09-08",
+        "funder": "all",
+        "cursor": 0,
+        "count": 1,
+        "count_new_papers": "1066",
+        "total": "1478"
+      }
+    ],
+    "collection": [
+      {
+        "title": "Zebrafish larval nitrogen excretion is flexible and resilient to loss of rhesus glycoproteins",
+        "authors": "Mes, W.; Haanen, R.; Arshad, A.; Klaren, P. H. M.; Schaaf, M. J. M.; Faught, E.; Nakada, T.; van Kessel, M. A. H. J.; Gorissen, M.",
+        "doi": "10.64898/2026.08.28.747819",
+        "date": "2026-09-01",
+        "version": "1",
+        "type": "new results",
+        "license": "cc_by_nc_nd",
+        "category": "physiology",
+        "jatsxml": "https://www.biorxiv.org/content/early/2026/09/01/2026.08.28.747819.source.xml",
+        "abstract": "Nitrogenous waste excretion is essential for all developmental stages of fish. In zebrafish, ammonia excretion involves rhesus glycoproteins Rhbg and Rhcgb.",
+        "published": "NA",
+        "server": "bioRxiv"
+      }
+    ]
+  }
+}

--- a/tests/test_biorxiv_medrxiv.py
+++ b/tests/test_biorxiv_medrxiv.py
@@ -1,0 +1,146 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+from biomni.tool import literature
+from biomni.tool.tool_description import literature as literature_description
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload() -> dict:
+    return json.loads((FIXTURES_DIR / "biorxiv_zebrafish.json").read_text(encoding="utf-8"))["response"]
+
+
+def fixture_record() -> dict:
+    return fixture_payload()["collection"][0]
+
+
+def test_extract_records_returns_collection_records():
+    records = literature._extract_biorxiv_medrxiv_records(fixture_payload())
+    assert len(records) == 1
+    assert records[0]["doi"] == "10.64898/2026.08.28.747819"
+
+
+def test_get_total_returns_provider_total():
+    assert literature._get_biorxiv_medrxiv_total(fixture_payload()) == 1478
+    assert literature._get_biorxiv_medrxiv_total({"messages": [{"total": "not-a-number"}]}) is None
+
+
+def test_format_record_uses_preprint_fields():
+    output = literature._format_biorxiv_medrxiv_record(fixture_record())
+    assert "Title: Zebrafish larval nitrogen excretion" in output
+    assert "Journal: bioRxiv" in output
+    assert "DOI: 10.64898/2026.08.28.747819" in output
+    assert "Posted: 2026-09-01" in output
+    assert "Category: physiology" in output
+    assert "URL: https://www.biorxiv.org/content/early/2026/09/01/2026.08.28.747819.source.xml" in output
+
+
+def test_record_matches_query_terms_and_category():
+    record = fixture_record()
+    assert literature._biorxiv_medrxiv_record_matches(record, ["zebrafish", "rhesus"], "physiology")
+    assert literature._biorxiv_medrxiv_record_matches(record, ["zebrafish"], "all")
+    assert not literature._biorxiv_medrxiv_record_matches(record, ["malaria"], "all")
+    assert not literature._biorxiv_medrxiv_record_matches(record, ["zebrafish"], "genomics")
+
+
+def test_search_biorxiv_medrxiv_filters_records():
+    session = Mock()
+    session.get.side_effect = [Response(fixture_payload()), Response({"collection": []})]
+    records = literature._search_biorxiv_medrxiv(
+        "zebrafish rhesus",
+        server="biorxiv",
+        max_papers=1,
+        days_back=7,
+        session=session,
+    )
+    assert records[0]["doi"] == "10.64898/2026.08.28.747819"
+    session.get.assert_called_once()
+
+
+def test_search_biorxiv_medrxiv_paginates_until_match():
+    session = Mock()
+    miss = fixture_payload()
+    miss["collection"] = [{**fixture_record(), "title": "Unrelated preprint", "abstract": "No matching terms"}]
+    session.get.side_effect = [Response(miss), Response(fixture_payload())]
+    records = literature._search_biorxiv_medrxiv(
+        "zebrafish rhesus",
+        server="biorxiv",
+        max_papers=1,
+        days_back=7,
+        session=session,
+    )
+    assert records[0]["title"].startswith("Zebrafish")
+    assert session.get.call_count == 2
+
+
+def test_search_biorxiv_medrxiv_stops_at_provider_total():
+    session = Mock()
+    miss = fixture_payload()
+    miss["messages"][0]["total"] = "1"
+    miss["collection"] = [{**fixture_record(), "title": "Unrelated preprint", "abstract": "No matching terms"}]
+    session.get.return_value = Response(miss)
+    records = literature._search_biorxiv_medrxiv(
+        "zebrafish rhesus",
+        server="biorxiv",
+        max_papers=1,
+        days_back=7,
+        session=session,
+    )
+    assert records == []
+    session.get.assert_called_once()
+
+
+def test_query_biorxiv_medrxiv_returns_formatted_results(monkeypatch):
+    monkeypatch.setattr(literature, "_search_biorxiv_medrxiv", lambda *args, **kwargs: [fixture_record()])
+    result = literature.query_biorxiv_medrxiv("zebrafish rhesus", max_papers=1, days_back=7)
+    assert "Title: Zebrafish larval nitrogen excretion" in result
+    assert "Journal: bioRxiv" in result
+    assert "Category: physiology" in result
+
+
+def test_query_biorxiv_medrxiv_returns_no_results_message(monkeypatch):
+    monkeypatch.setattr(literature, "_search_biorxiv_medrxiv", lambda *args, **kwargs: [])
+    result = literature.query_biorxiv_medrxiv("missing", max_papers=1)
+    assert result == "No preprints found on bioRxiv/medRxiv."
+
+
+def test_query_biorxiv_medrxiv_rejects_empty_query():
+    result = literature.query_biorxiv_medrxiv("   ")
+    assert result == "Error querying bioRxiv/medRxiv: Query must not be empty."
+
+
+def test_query_biorxiv_medrxiv_rejects_unknown_server():
+    result = literature.query_biorxiv_medrxiv("zebrafish", server="arxiv")
+    assert result == 'Error querying bioRxiv/medRxiv: Server must be "biorxiv" or "medrxiv".'
+
+
+def test_query_biorxiv_medrxiv_returns_error_string_on_http_error(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise requests.HTTPError("500 Server Error")
+
+    monkeypatch.setattr(literature, "_search_biorxiv_medrxiv", raise_error)
+    result = literature.query_biorxiv_medrxiv("zebrafish")
+    assert result == "Error querying bioRxiv/medRxiv: 500 Server Error"
+
+
+def test_biorxiv_medrxiv_tool_description_is_registered():
+    names = {entry["name"] for entry in literature_description.description}
+    assert "query_biorxiv_medrxiv" in names


### PR DESCRIPTION
This PR adds a new A1-visible literature/database tool for direct bioRxiv and medRxiv preprint lookup.

Changes:

adds `query_biorxiv_medrxiv` to `biomni/tool/literature.py`
adds the matching tool description entry in `biomni/tool/tool_description/literature.py`
adds focused fixture-backed tests in `tests/test_biorxiv_medrxiv.py`
adds a reduced public bioRxiv fixture in `tests/fixtures/biorxiv_zebrafish.json`

`query_biorxiv_medrxiv` accepts a query and can search either `server="biorxiv"` or `server="medrxiv"`. It queries the public bioRxiv/medRxiv metadata API over a recent date window and filters title, abstract, authors, category, and DOI locally.

Testing
Focused tests and lint passed:

```bash
python -m pytest tests/test_biorxiv_medrxiv.py
python -m ruff check biomni/tool/literature.py biomni/tool/tool_description/literature.py tests/test_biorxiv_medrxiv.py
```

Result:

```text
13 passed, 1 warning
All checks passed!
```

Manual Live Prompt Validation
Manual local-LLM prompt validation passed against the local OpenAI-compatible Qwen endpoint with A1 tool retrieval enabled.

Prompt:

```text
Use the Biomni literature tool query_biorxiv_medrxiv exactly once to find one recent bioRxiv preprint about Zebrafish larval nitrogen excretion. Use max_papers=1, server='biorxiv', and days_back=7. After the observation, respond with a <solution> that reports the title, posted date, category, DOI, and whether it is from bioRxiv. If the observation is an error, report the exact error in the <solution>.
```

Result:

A1 selected `query_biorxiv_medrxiv`
A1 generated an `<execute>` block
The tool queried live bioRxiv metadata
A1 completed with a `<solution>`

Observed tool output:

```text
Title: Zebrafish larval nitrogen excretion is flexible and resilient to loss of rhesus glycoproteins
Journal: bioRxiv
DOI: 10.64898/2026.08.28.747819
Posted: 2026-09-01
Category: physiology
URL: https://www.biorxiv.org/content/early/2026/09/01/2026.08.28.747819.source.xml
```

Notes
The bioRxiv/medRxiv public API is metadata/date-range based rather than a general indexed search API. This PR keeps the implementation legacy-style and API-native by fetching recent metadata pages and filtering matching records locally.