### PR TITLE
Add CELLxGENE collection database tool

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -445,6 +445,129 @@ def _format_query_results(result, options=None):
     return formatted
 
 
+def _extract_cellxgene_collections(payload) -> list[dict]:
+    if isinstance(payload, list):
+        return [collection for collection in payload if isinstance(collection, dict)]
+    if isinstance(payload, dict):
+        collections = payload.get("collections", [])
+        if isinstance(collections, list):
+            return [collection for collection in collections if isinstance(collection, dict)]
+    return []
+
+
+def _get_cellxgene_labels(values) -> list[str]:
+    labels = []
+    if isinstance(values, list):
+        for value in values:
+            if isinstance(value, dict):
+                label = value.get("label") or value.get("ontology_term_id")
+                if label:
+                    labels.append(str(label))
+            elif isinstance(value, str):
+                labels.append(value)
+    elif isinstance(values, str):
+        labels.append(values)
+    return labels
+
+
+def _get_cellxgene_dataset_labels(collection: dict, field: str) -> list[str]:
+    labels = []
+    for dataset in collection.get("datasets", []):
+        if isinstance(dataset, dict):
+            labels.extend(_get_cellxgene_labels(dataset.get(field)))
+    return sorted(set(labels))
+
+
+def _cellxgene_collection_matches(collection: dict, terms: list[str]) -> bool:
+    if not terms:
+        return True
+
+    searchable_parts = [
+        collection.get("name", ""),
+        collection.get("description", ""),
+        collection.get("doi", ""),
+        " ".join(collection.get("consortia") or []),
+    ]
+    for dataset in collection.get("datasets", []):
+        if isinstance(dataset, dict):
+            for field in ("assay", "disease", "organism", "tissue", "suspension_type"):
+                searchable_parts.extend(_get_cellxgene_labels(dataset.get(field)))
+
+    searchable_text = " ".join(str(part) for part in searchable_parts if part).lower()
+    return all(term in searchable_text for term in terms)
+
+
+def _format_cellxgene_collection(collection: dict) -> str:
+    name = collection.get("name") or "N/A"
+    collection_id = collection.get("collection_id") or collection.get("id") or "N/A"
+    collection_url = collection.get("collection_url") or (
+        f"https://cellxgene.cziscience.com/collections/{collection_id}" if collection_id != "N/A" else "N/A"
+    )
+    doi = collection.get("doi") or "N/A"
+    published_at = collection.get("published_at") or "N/A"
+    consortia = ", ".join(collection.get("consortia") or []) or "N/A"
+    datasets = collection.get("datasets", [])
+    dataset_count = len(datasets) if isinstance(datasets, list) else 0
+    organisms = ", ".join(_get_cellxgene_dataset_labels(collection, "organism")) or "N/A"
+    tissues = ", ".join(_get_cellxgene_dataset_labels(collection, "tissue")[:5]) or "N/A"
+    assays = ", ".join(_get_cellxgene_dataset_labels(collection, "assay")[:5]) or "N/A"
+    diseases = ", ".join(_get_cellxgene_dataset_labels(collection, "disease")[:5]) or "N/A"
+    return (
+        f"Collection: {name}\n"
+        f"Collection ID: {collection_id}\n"
+        f"URL: {collection_url}\n"
+        f"DOI: {doi}\n"
+        f"Published: {published_at}\n"
+        f"Consortia: {consortia}\n"
+        f"Dataset Count: {dataset_count}\n"
+        f"Organisms: {organisms}\n"
+        f"Tissues: {tissues}\n"
+        f"Assays: {assays}\n"
+        f"Diseases: {diseases}"
+    )
+
+
+def _search_cellxgene_collections(query: str, session: requests.Session | None = None) -> list[dict]:
+    active_session = session or requests.Session()
+    response = active_session.get(
+        "https://api.cellxgene.cziscience.com/curation/v1/collections",
+        timeout=30,
+    )
+    response.raise_for_status()
+    collections = _extract_cellxgene_collections(response.json())
+    terms = [term.lower() for term in query.split() if term.strip()]
+    return [collection for collection in collections if _cellxgene_collection_matches(collection, terms)]
+
+
+def query_cellxgene_collections(query: str, max_results: int = 5) -> str:
+    """Query public CELLxGENE Discover collections by metadata text.
+
+    Parameters
+    ----------
+    - query (str): The metadata query string, such as a tissue, organism, disease, assay, or collection title.
+    - max_results (int): The maximum number of matching collections to return (default: 5).
+
+    Returns
+    -------
+    - str: The formatted CELLxGENE collection results or an error message.
+
+    """
+    try:
+        search_query = query.strip()
+        if not search_query:
+            return "Error querying CELLxGENE: Query must not be empty."
+
+        result_count = max(1, int(max_results))
+        collections = _search_cellxgene_collections(search_query)
+        if collections:
+            return "\n\n".join(_format_cellxgene_collection(collection) for collection in collections[:result_count])
+        return "No CELLxGENE collections found."
+    except requests.RequestException as e:
+        return f"Error querying CELLxGENE: {e}"
+    except ValueError as e:
+        return f"Error querying CELLxGENE: {e}"
+
+
 def query_uniprot(
     prompt=None,
     endpoint=None,

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -1,5 +1,25 @@
 description = [
     {
+        "description": "Query public CELLxGENE Discover collections by metadata text.",
+        "name": "query_cellxgene_collections",
+        "optional_parameters": [
+            {
+                "default": 5,
+                "description": "The maximum number of matching collections to return.",
+                "name": "max_results",
+                "type": "int",
+            }
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The metadata query string, such as a tissue, organism, disease, assay, or collection title.",
+                "name": "query",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Query the UniProt REST API using either natural language or a direct endpoint.",
         "name": "query_uniprot",
         "optional_parameters": [

--- a/tests/fixtures/cellxgene_retina_collection.json
+++ b/tests/fixtures/cellxgene_retina_collection.json
@@ -1,0 +1,71 @@
+{
+  "attribution": {
+    "provider": "CELLxGENE Discover",
+    "source_url": "https://api.cellxgene.cziscience.com/curation/v1/collections",
+    "retrieved_date": "2026-09-08",
+    "note": "Public CELLxGENE collection response reduced to one collection and one dataset."
+  },
+  "response": [
+    {
+      "collection_id": "af893e86-8e9f-41f1-a474-ef05359b1fb7",
+      "collection_url": "https://cellxgene.cziscience.com/collections/af893e86-8e9f-41f1-a474-ef05359b1fb7",
+      "collection_version_id": "c1b538fd-0f01-41c8-a504-6f44626916c2",
+      "consortia": [
+        "CZI Cell Science"
+      ],
+      "contact_email": "ruichen@bcm.edu",
+      "contact_name": "Rui Chen",
+      "created_at": "2026-06-09T23:02:06+00:00",
+      "curator_name": "Jennifer Yu-Sheng Chien",
+      "description": "Single-nuclei RNA-seq were carried out to profile well-characterized healthy human retina from six individual donors using the 10x Genomics technologies.",
+      "doi": "10.1016/j.xgen.2023.100343",
+      "name": "Single-cell transcriptomic atlas for adult human retina",
+      "published_at": "2021-10-29T22:14:24+00:00",
+      "visibility": "PUBLIC",
+      "datasets": [
+        {
+          "assay": [
+            {
+              "label": "10x 3' v3",
+              "ontology_term_id": "EFO:0009922"
+            }
+          ],
+          "dataset_id": "ed419b4e-db9b-40f1-8593-68fdf8dfb076",
+          "dataset_version_id": "c8da6eeb-84d7-4379-a332-1bf6107859d6",
+          "disease": [
+            {
+              "label": "normal",
+              "ontology_term_id": "PATO:0000461"
+            }
+          ],
+          "organism": [
+            {
+              "label": "Homo sapiens",
+              "ontology_term_id": "NCBITaxon:9606"
+            }
+          ],
+          "suspension_type": [
+            "nucleus"
+          ],
+          "tissue": [
+            {
+              "label": "fovea centralis",
+              "ontology_term_id": "UBERON:0001786",
+              "tissue_type": "tissue"
+            },
+            {
+              "label": "macula lutea proper",
+              "ontology_term_id": "UBERON:0002822",
+              "tissue_type": "tissue"
+            },
+            {
+              "label": "peripheral region of retina",
+              "ontology_term_id": "UBERON:0013682",
+              "tissue_type": "tissue"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/cellxgene_retina_collection.json
+++ b/tests/fixtures/cellxgene_retina_collection.json
@@ -1,71 +1,67 @@
 {
-  "attribution": {
-    "provider": "CELLxGENE Discover",
-    "source_url": "https://api.cellxgene.cziscience.com/curation/v1/collections",
-    "retrieved_date": "2026-09-08",
-    "note": "Public CELLxGENE collection response reduced to one collection and one dataset."
-  },
-  "response": [
-    {
-      "collection_id": "af893e86-8e9f-41f1-a474-ef05359b1fb7",
-      "collection_url": "https://cellxgene.cziscience.com/collections/af893e86-8e9f-41f1-a474-ef05359b1fb7",
-      "collection_version_id": "c1b538fd-0f01-41c8-a504-6f44626916c2",
-      "consortia": [
-        "CZI Cell Science"
-      ],
-      "contact_email": "ruichen@bcm.edu",
-      "contact_name": "Rui Chen",
-      "created_at": "2026-06-09T23:02:06+00:00",
-      "curator_name": "Jennifer Yu-Sheng Chien",
-      "description": "Single-nuclei RNA-seq were carried out to profile well-characterized healthy human retina from six individual donors using the 10x Genomics technologies.",
-      "doi": "10.1016/j.xgen.2023.100343",
-      "name": "Single-cell transcriptomic atlas for adult human retina",
-      "published_at": "2021-10-29T22:14:24+00:00",
-      "visibility": "PUBLIC",
-      "datasets": [
-        {
-          "assay": [
-            {
-              "label": "10x 3' v3",
-              "ontology_term_id": "EFO:0009922"
-            }
-          ],
-          "dataset_id": "ed419b4e-db9b-40f1-8593-68fdf8dfb076",
-          "dataset_version_id": "c8da6eeb-84d7-4379-a332-1bf6107859d6",
-          "disease": [
-            {
-              "label": "normal",
-              "ontology_term_id": "PATO:0000461"
-            }
-          ],
-          "organism": [
-            {
-              "label": "Homo sapiens",
-              "ontology_term_id": "NCBITaxon:9606"
-            }
-          ],
-          "suspension_type": [
-            "nucleus"
-          ],
-          "tissue": [
-            {
-              "label": "fovea centralis",
-              "ontology_term_id": "UBERON:0001786",
-              "tissue_type": "tissue"
-            },
-            {
-              "label": "macula lutea proper",
-              "ontology_term_id": "UBERON:0002822",
-              "tissue_type": "tissue"
-            },
-            {
-              "label": "peripheral region of retina",
-              "ontology_term_id": "UBERON:0013682",
-              "tissue_type": "tissue"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+	"attribution": {
+		"provider": "CELLxGENE Discover",
+		"source_url": "https://api.cellxgene.cziscience.com/curation/v1/collections",
+		"retrieved_date": "2026-09-08",
+		"note": "Public CELLxGENE collection response reduced to one collection and one dataset."
+	},
+	"response": [
+		{
+			"collection_id": "af893e86-8e9f-41f1-a474-ef05359b1fb7",
+			"collection_url": "https://cellxgene.cziscience.com/collections/af893e86-8e9f-41f1-a474-ef05359b1fb7",
+			"collection_version_id": "c1b538fd-0f01-41c8-a504-6f44626916c2",
+			"consortia": ["CZI Cell Science"],
+			"contact_email": "ruichen@bcm.edu",
+			"contact_name": "Rui Chen",
+			"created_at": "2026-06-09T23:02:06+00:00",
+			"curator_name": "Jennifer Yu-Sheng Chien",
+			"description": "Single-nuclei RNA-seq were carried out to profile well-characterized healthy human retina from six individual donors using the 10x Genomics technologies.",
+			"doi": "10.1016/j.xgen.2023.100343",
+			"name": "Single-cell transcriptomic atlas for adult human retina",
+			"published_at": "2021-10-29T22:14:24+00:00",
+			"visibility": "PUBLIC",
+			"datasets": [
+				{
+					"assay": [
+						{
+							"label": "10x 3' v3",
+							"ontology_term_id": "EFO:0009922"
+						}
+					],
+					"dataset_id": "ed419b4e-db9b-40f1-8593-68fdf8dfb076",
+					"dataset_version_id": "c8da6eeb-84d7-4379-a332-1bf6107859d6",
+					"disease": [
+						{
+							"label": "normal",
+							"ontology_term_id": "PATO:0000461"
+						}
+					],
+					"organism": [
+						{
+							"label": "Homo sapiens",
+							"ontology_term_id": "NCBITaxon:9606"
+						}
+					],
+					"suspension_type": ["nucleus"],
+					"tissue": [
+						{
+							"label": "fovea centralis",
+							"ontology_term_id": "UBERON:0001786",
+							"tissue_type": "tissue"
+						},
+						{
+							"label": "macula lutea proper",
+							"ontology_term_id": "UBERON:0002822",
+							"tissue_type": "tissue"
+						},
+						{
+							"label": "peripheral region of retina",
+							"ontology_term_id": "UBERON:0013682",
+							"tissue_type": "tissue"
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/tests/test_cellxgene_collections.py
+++ b/tests/test_cellxgene_collections.py
@@ -1,0 +1,130 @@
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+
+bio_module = types.ModuleType("Bio")
+blast_module = types.ModuleType("Bio.Blast")
+blast_module.NCBIWWW = object()
+blast_module.NCBIXML = object()
+seq_module = types.ModuleType("Bio.Seq")
+seq_module.Seq = str
+sys.modules.setdefault("Bio", bio_module)
+sys.modules.setdefault("Bio.Blast", blast_module)
+sys.modules.setdefault("Bio.Seq", seq_module)
+
+from biomni.tool import database
+from biomni.tool.tool_description import database as database_description
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload():
+    return json.loads((FIXTURES_DIR / "cellxgene_retina_collection.json").read_text(encoding="utf-8"))["response"]
+
+
+def fixture_collection():
+    return fixture_payload()[0]
+
+
+def test_extract_cellxgene_collections_returns_list_payload():
+    collections = database._extract_cellxgene_collections(fixture_payload())
+    assert len(collections) == 1
+    assert collections[0]["collection_id"] == "af893e86-8e9f-41f1-a474-ef05359b1fb7"
+
+
+def test_extract_cellxgene_collections_returns_dict_payload():
+    collections = database._extract_cellxgene_collections({"collections": fixture_payload()})
+    assert len(collections) == 1
+    assert collections[0]["name"].startswith("Single-cell transcriptomic atlas")
+
+
+def test_get_cellxgene_labels_handles_ontology_terms_and_strings():
+    values = [{"label": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606"}, "nucleus"]
+    assert database._get_cellxgene_labels(values) == ["Homo sapiens", "nucleus"]
+
+
+def test_get_cellxgene_dataset_labels_deduplicates_values():
+    labels = database._get_cellxgene_dataset_labels(fixture_collection(), "organism")
+    assert labels == ["Homo sapiens"]
+
+
+def test_cellxgene_collection_matches_query_terms():
+    collection = fixture_collection()
+    assert database._cellxgene_collection_matches(collection, ["human", "retina"])
+    assert database._cellxgene_collection_matches(collection, ["homo", "sapiens"])
+    assert database._cellxgene_collection_matches(collection, ["fovea"])
+    assert not database._cellxgene_collection_matches(collection, ["zebrafish"])
+
+
+def test_format_cellxgene_collection_returns_metadata_summary():
+    output = database._format_cellxgene_collection(fixture_collection())
+    assert "Collection: Single-cell transcriptomic atlas for adult human retina" in output
+    assert "Collection ID: af893e86-8e9f-41f1-a474-ef05359b1fb7" in output
+    assert "DOI: 10.1016/j.xgen.2023.100343" in output
+    assert "Dataset Count: 1" in output
+    assert "Organisms: Homo sapiens" in output
+    assert "Tissues: fovea centralis, macula lutea proper, peripheral region of retina" in output
+    assert "Assays: 10x 3' v3" in output
+    assert "Diseases: normal" in output
+
+
+def test_search_cellxgene_collections_calls_public_endpoint():
+    session = Mock()
+    session.get.return_value = Response(fixture_payload())
+    collections = database._search_cellxgene_collections("human retina", session=session)
+    assert len(collections) == 1
+    session.get.assert_called_once_with(
+        "https://api.cellxgene.cziscience.com/curation/v1/collections",
+        timeout=30,
+    )
+
+
+def test_query_cellxgene_collections_returns_formatted_result(monkeypatch):
+    monkeypatch.setattr(database, "_search_cellxgene_collections", lambda query: [fixture_collection()])
+    result = database.query_cellxgene_collections("human retina", max_results=1)
+    assert "Collection: Single-cell transcriptomic atlas for adult human retina" in result
+    assert "Dataset Count: 1" in result
+
+
+def test_query_cellxgene_collections_returns_no_results_message(monkeypatch):
+    monkeypatch.setattr(database, "_search_cellxgene_collections", lambda query: [])
+    result = database.query_cellxgene_collections("missing")
+    assert result == "No CELLxGENE collections found."
+
+
+def test_query_cellxgene_collections_rejects_empty_query():
+    result = database.query_cellxgene_collections("   ")
+    assert result == "Error querying CELLxGENE: Query must not be empty."
+
+
+def test_query_cellxgene_collections_returns_error_string_on_http_error(monkeypatch):
+    def raise_error(query):
+        raise requests.HTTPError("500 Server Error")
+
+    monkeypatch.setattr(database, "_search_cellxgene_collections", raise_error)
+    result = database.query_cellxgene_collections("retina")
+    assert result == "Error querying CELLxGENE: 500 Server Error"
+
+
+def test_cellxgene_tool_description_is_registered():
+    names = {entry["name"] for entry in database_description.description}
+    assert "query_cellxgene_collections" in names


### PR DESCRIPTION
This PR adds a new A1-visible database tool for public CELLxGENE Discover collection lookup.

Changes:

adds `query_cellxgene_collections` to `biomni/tool/database.py`
adds the matching tool description entry in `biomni/tool/tool_description/database.py`
adds focused fixture-backed tests in `tests/test_cellxgene_collections.py`
adds a reduced public CELLxGENE collection fixture in `tests/fixtures/cellxgene_retina_collection.json`

`query_cellxgene_collections` accepts a metadata query string and optional `max_results`, queries the public CELLxGENE Discover collections endpoint, filters collection and dataset metadata locally, and returns formatted collection summaries.

Testing
Focused tests and lint passed:

```bash
python -m pytest tests/test_cellxgene_collections.py
python -m ruff check biomni/tool/database.py biomni/tool/tool_description/database.py tests/test_cellxgene_collections.py
```

Result:

```text
12 passed
All checks passed!
```

Manual Live Prompt Validation
Manual local-LLM prompt validation passed against the local OpenAI-compatible Qwen endpoint with A1 tool retrieval enabled.

Prompt:

```text
Use Python to import the Biomni database tool exactly as follows: from biomni.tool.database import query_cellxgene_collections. Then call query_cellxgene_collections('human retina', max_results=1) exactly once and print the result. After the observation, respond with a <solution> that reports the collection name, collection ID, DOI, dataset count, organisms, tissues, and assays. If the observation is an error, report the exact error in the <solution>.
```

Result:

A1 selected `query_cellxgene_collections`
A1 generated an `<execute>` block
The tool queried live CELLxGENE Discover
A1 completed with a `<solution>`

Observed tool output:

```text
Collection: Single-cell transcriptomic atlas for adult human retina
Collection ID: af893e86-8e9f-41f1-a474-ef05359b1fb7
URL: https://cellxgene.cziscience.com/collections/af893e86-8e9f-41f1-a474-ef05359b1fb7
DOI: 10.1016/j.xgen.2023.100298
Published: 2021-10-29T22:14:24+00:00
Consortia: CZI Cell Science
Dataset Count: 7
Organisms: Homo sapiens
Tissues: fovea centralis, macula lutea proper, peripheral region of retina
Assays: 10x 3' v3
Diseases: normal
```

Notes
This follows Biomni's legacy database-tool pattern: the implementation is added directly to `biomni/tool/database.py`, the A1-visible description is added directly to `biomni/tool/tool_description/database.py`, and tests use a local fixture with a mocked response.

The official `cellxgene-census` Python client is not installed in this repo environment, so this PR avoids dependency and packaging changes by using the public CELLxGENE Discover REST endpoint with `requests`.