### PR TITLE
Add Human Cell Atlas project database tool

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -445,6 +445,132 @@ def _format_query_results(result, options=None):
     return formatted
 
 
+def _extract_hca_projects(payload: dict) -> list[dict]:
+    hits = payload.get("hits", [])
+    if isinstance(hits, list):
+        return [hit for hit in hits if isinstance(hit, dict)]
+    return []
+
+
+def _get_hca_values(records, field: str) -> list[str]:
+    values = []
+    if isinstance(records, list):
+        for record in records:
+            if isinstance(record, dict):
+                value = record.get(field)
+                if isinstance(value, list):
+                    values.extend(str(item) for item in value if item)
+                elif value:
+                    values.append(str(value))
+    return sorted(set(values))
+
+
+def _hca_project_matches(hit: dict, terms: list[str]) -> bool:
+    if not terms:
+        return True
+
+    searchable_parts = []
+    for project in hit.get("projects", []):
+        if isinstance(project, dict):
+            for field in ("projectTitle", "projectShortname", "projectDescription", "dataUseRestriction"):
+                searchable_parts.append(project.get(field) or "")
+            for publication in project.get("publications", []):
+                if isinstance(publication, dict):
+                    searchable_parts.append(publication.get("publicationTitle") or "")
+
+    for record_group in ("samples", "specimens", "donorOrganisms", "cellSuspensions", "protocols"):
+        for record in hit.get(record_group, []):
+            if isinstance(record, dict):
+                for value in record.values():
+                    if isinstance(value, list):
+                        searchable_parts.extend(str(item) for item in value if item)
+                    elif value:
+                        searchable_parts.append(str(value))
+
+    searchable_text = " ".join(searchable_parts).lower()
+    return all(term in searchable_text for term in terms)
+
+
+def _format_hca_project(hit: dict) -> str:
+    project = {}
+    if hit.get("projects") and isinstance(hit["projects"][0], dict):
+        project = hit["projects"][0]
+
+    project_id = project.get("projectId") or hit.get("entryId") or "N/A"
+    title = project.get("projectTitle") or "N/A"
+    shortname = project.get("projectShortname") or "N/A"
+    data_use = project.get("dataUseRestriction") or "N/A"
+    organs = ", ".join(_get_hca_values(hit.get("samples", []), "organ")) or "N/A"
+    organ_parts = ", ".join(_get_hca_values(hit.get("samples", []), "organPart")) or "N/A"
+    species = ", ".join(_get_hca_values(hit.get("donorOrganisms", []), "genusSpecies")) or "N/A"
+    diseases = ", ".join(_get_hca_values(hit.get("samples", []), "disease")) or "N/A"
+    library_methods = ", ".join(_get_hca_values(hit.get("protocols", []), "libraryConstructionApproach")) or "N/A"
+    cell_counts = [record.get("totalCells") for record in hit.get("cellSuspensions", []) if isinstance(record, dict)]
+    total_cells = sum(count for count in cell_counts if isinstance(count, int))
+    file_summaries = []
+    for summary in hit.get("fileTypeSummaries", []):
+        if isinstance(summary, dict) and summary.get("format"):
+            file_summaries.append(f"{summary.get('format')} ({summary.get('count', 'N/A')})")
+    file_summary = ", ".join(file_summaries[:5]) or "N/A"
+    portal_url = f"https://data.humancellatlas.org/explore/projects/{project_id}" if project_id != "N/A" else "N/A"
+    return (
+        f"Project: {title}\n"
+        f"Project ID: {project_id}\n"
+        f"Short Name: {shortname}\n"
+        f"Portal URL: {portal_url}\n"
+        f"Data Use Restriction: {data_use}\n"
+        f"Organs: {organs}\n"
+        f"Organ Parts: {organ_parts}\n"
+        f"Species: {species}\n"
+        f"Diseases: {diseases}\n"
+        f"Library Methods: {library_methods}\n"
+        f"Total Cells: {total_cells if total_cells else 'N/A'}\n"
+        f"File Types: {file_summary}"
+    )
+
+
+def _search_hca_projects(query: str, max_results: int = 5, session: requests.Session | None = None) -> list[dict]:
+    active_session = session or requests.Session()
+    response = active_session.get(
+        "https://service.azul.data.humancellatlas.org/index/projects",
+        params={"size": 10},
+        timeout=30,
+    )
+    response.raise_for_status()
+    hits = _extract_hca_projects(response.json())
+    terms = [term.lower() for term in query.split() if term.strip()]
+    return [hit for hit in hits if _hca_project_matches(hit, terms)][:max_results]
+
+
+def query_human_cell_atlas_projects(query: str, max_results: int = 5) -> str:
+    """Query public Human Cell Atlas project metadata.
+
+    Parameters
+    ----------
+    - query (str): The metadata query string, such as an organ, species, disease, assay, or project title.
+    - max_results (int): The maximum number of matching projects to return (default: 5).
+
+    Returns
+    -------
+    - str: The formatted Human Cell Atlas project results or an error message.
+
+    """
+    try:
+        search_query = query.strip()
+        if not search_query:
+            return "Error querying Human Cell Atlas: Query must not be empty."
+
+        result_count = max(1, int(max_results))
+        projects = _search_hca_projects(search_query, max_results=result_count)
+        if projects:
+            return "\n\n".join(_format_hca_project(project) for project in projects)
+        return "No Human Cell Atlas projects found."
+    except requests.RequestException as e:
+        return f"Error querying Human Cell Atlas: {e}"
+    except ValueError as e:
+        return f"Error querying Human Cell Atlas: {e}"
+
+
 def query_uniprot(
     prompt=None,
     endpoint=None,

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -1,5 +1,25 @@
 description = [
     {
+        "description": "Query public Human Cell Atlas project metadata.",
+        "name": "query_human_cell_atlas_projects",
+        "optional_parameters": [
+            {
+                "default": 5,
+                "description": "The maximum number of matching projects to return.",
+                "name": "max_results",
+                "type": "int",
+            }
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The metadata query string, such as an organ, species, disease, assay, or project title.",
+                "name": "query",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Query the UniProt REST API using either natural language or a direct endpoint.",
         "name": "query_uniprot",
         "optional_parameters": [

--- a/tests/fixtures/hca_brain_project.json
+++ b/tests/fixtures/hca_brain_project.json
@@ -1,104 +1,78 @@
 {
-  "attribution": {
-    "provider": "Human Cell Atlas Data Browser",
-    "source_url": "https://service.azul.data.humancellatlas.org/index/projects?size=1",
-    "retrieved_date": "2026-09-08",
-    "note": "Public HCA Azul project response reduced to one project."
-  },
-  "response": {
-    "pagination": {
-      "count": 1,
-      "total": 532,
-      "size": 1
-    },
-    "hits": [
-      {
-        "entryId": "74b6d569-3b11-42ef-b6b1-a0454522b4a0",
-        "projects": [
-          {
-            "projectId": "74b6d569-3b11-42ef-b6b1-a0454522b4a0",
-            "projectTitle": "1.3 Million Brain Cells from E18 Mice",
-            "projectShortname": "1M Neurons",
-            "laboratory": [
-              "Human Cell Atlas Data Coordination Platform"
-            ],
-            "estimatedCellCount": 1330000,
-            "dataUseRestriction": "NRES",
-            "projectDescription": "Cortex, hippocampus, and subventricular zone were profiled with single-cell RNA sequencing.",
-            "publications": [
-              {
-                "publicationTitle": "Massively parallel digital transcriptional profiling of single cells",
-                "publicationUrl": "https://doi.org/10.1038/ncomms14049",
-                "doi": "10.1038/ncomms14049"
-              }
-            ]
-          }
-        ],
-        "samples": [
-          {
-            "organ": [
-              "brain"
-            ],
-            "organPart": [
-              "cortex"
-            ],
-            "disease": [
-              "normal"
-            ]
-          }
-        ],
-        "donorOrganisms": [
-          {
-            "donorCount": 2,
-            "developmentStage": [
-              "mouse embryo stage"
-            ],
-            "genusSpecies": [
-              "Mus musculus"
-            ],
-            "biologicalSex": [
-              "unknown"
-            ],
-            "disease": [
-              "normal"
-            ]
-          }
-        ],
-        "cellSuspensions": [
-          {
-            "organ": [
-              "brain"
-            ],
-            "organPart": [
-              "cortex"
-            ],
-            "selectedCellType": [
-              "neuron"
-            ],
-            "totalCells": 1330000
-          }
-        ],
-        "protocols": [
-          {
-            "libraryConstructionApproach": [
-              "10x 3' v2"
-            ],
-            "nucleicAcidSource": [
-              "single cell"
-            ]
-          }
-        ],
-        "fileTypeSummaries": [
-          {
-            "count": 16377,
-            "format": "fastq"
-          },
-          {
-            "count": 1,
-            "format": "h5"
-          }
-        ]
-      }
-    ]
-  }
+	"attribution": {
+		"provider": "Human Cell Atlas Data Browser",
+		"source_url": "https://service.azul.data.humancellatlas.org/index/projects?size=1",
+		"retrieved_date": "2026-09-08",
+		"note": "Public HCA Azul project response reduced to one project."
+	},
+	"response": {
+		"pagination": {
+			"count": 1,
+			"total": 532,
+			"size": 1
+		},
+		"hits": [
+			{
+				"entryId": "74b6d569-3b11-42ef-b6b1-a0454522b4a0",
+				"projects": [
+					{
+						"projectId": "74b6d569-3b11-42ef-b6b1-a0454522b4a0",
+						"projectTitle": "1.3 Million Brain Cells from E18 Mice",
+						"projectShortname": "1M Neurons",
+						"laboratory": ["Human Cell Atlas Data Coordination Platform"],
+						"estimatedCellCount": 1330000,
+						"dataUseRestriction": "NRES",
+						"projectDescription": "Cortex, hippocampus, and subventricular zone were profiled with single-cell RNA sequencing.",
+						"publications": [
+							{
+								"publicationTitle": "Massively parallel digital transcriptional profiling of single cells",
+								"publicationUrl": "https://doi.org/10.1038/ncomms14049",
+								"doi": "10.1038/ncomms14049"
+							}
+						]
+					}
+				],
+				"samples": [
+					{
+						"organ": ["brain"],
+						"organPart": ["cortex"],
+						"disease": ["normal"]
+					}
+				],
+				"donorOrganisms": [
+					{
+						"donorCount": 2,
+						"developmentStage": ["mouse embryo stage"],
+						"genusSpecies": ["Mus musculus"],
+						"biologicalSex": ["unknown"],
+						"disease": ["normal"]
+					}
+				],
+				"cellSuspensions": [
+					{
+						"organ": ["brain"],
+						"organPart": ["cortex"],
+						"selectedCellType": ["neuron"],
+						"totalCells": 1330000
+					}
+				],
+				"protocols": [
+					{
+						"libraryConstructionApproach": ["10x 3' v2"],
+						"nucleicAcidSource": ["single cell"]
+					}
+				],
+				"fileTypeSummaries": [
+					{
+						"count": 16377,
+						"format": "fastq"
+					},
+					{
+						"count": 1,
+						"format": "h5"
+					}
+				]
+			}
+		]
+	}
 }

--- a/tests/fixtures/hca_brain_project.json
+++ b/tests/fixtures/hca_brain_project.json
@@ -1,0 +1,104 @@
+{
+  "attribution": {
+    "provider": "Human Cell Atlas Data Browser",
+    "source_url": "https://service.azul.data.humancellatlas.org/index/projects?size=1",
+    "retrieved_date": "2026-09-08",
+    "note": "Public HCA Azul project response reduced to one project."
+  },
+  "response": {
+    "pagination": {
+      "count": 1,
+      "total": 532,
+      "size": 1
+    },
+    "hits": [
+      {
+        "entryId": "74b6d569-3b11-42ef-b6b1-a0454522b4a0",
+        "projects": [
+          {
+            "projectId": "74b6d569-3b11-42ef-b6b1-a0454522b4a0",
+            "projectTitle": "1.3 Million Brain Cells from E18 Mice",
+            "projectShortname": "1M Neurons",
+            "laboratory": [
+              "Human Cell Atlas Data Coordination Platform"
+            ],
+            "estimatedCellCount": 1330000,
+            "dataUseRestriction": "NRES",
+            "projectDescription": "Cortex, hippocampus, and subventricular zone were profiled with single-cell RNA sequencing.",
+            "publications": [
+              {
+                "publicationTitle": "Massively parallel digital transcriptional profiling of single cells",
+                "publicationUrl": "https://doi.org/10.1038/ncomms14049",
+                "doi": "10.1038/ncomms14049"
+              }
+            ]
+          }
+        ],
+        "samples": [
+          {
+            "organ": [
+              "brain"
+            ],
+            "organPart": [
+              "cortex"
+            ],
+            "disease": [
+              "normal"
+            ]
+          }
+        ],
+        "donorOrganisms": [
+          {
+            "donorCount": 2,
+            "developmentStage": [
+              "mouse embryo stage"
+            ],
+            "genusSpecies": [
+              "Mus musculus"
+            ],
+            "biologicalSex": [
+              "unknown"
+            ],
+            "disease": [
+              "normal"
+            ]
+          }
+        ],
+        "cellSuspensions": [
+          {
+            "organ": [
+              "brain"
+            ],
+            "organPart": [
+              "cortex"
+            ],
+            "selectedCellType": [
+              "neuron"
+            ],
+            "totalCells": 1330000
+          }
+        ],
+        "protocols": [
+          {
+            "libraryConstructionApproach": [
+              "10x 3' v2"
+            ],
+            "nucleicAcidSource": [
+              "single cell"
+            ]
+          }
+        ],
+        "fileTypeSummaries": [
+          {
+            "count": 16377,
+            "format": "fastq"
+          },
+          {
+            "count": 1,
+            "format": "h5"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_human_cell_atlas_projects.py
+++ b/tests/test_human_cell_atlas_projects.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+from biomni.tool import database
+from biomni.tool.tool_description import database as database_description
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload():
+    return json.loads((FIXTURES_DIR / "hca_brain_project.json").read_text(encoding="utf-8"))["response"]
+
+
+def fixture_project():
+    return fixture_payload()["hits"][0]
+
+
+def test_extract_hca_projects_returns_hits():
+    projects = database._extract_hca_projects(fixture_payload())
+    assert len(projects) == 1
+    assert projects[0]["entryId"] == "74b6d569-3b11-42ef-b6b1-a0454522b4a0"
+
+
+def test_get_hca_values_deduplicates_values():
+    values = database._get_hca_values(
+        [{"organ": ["brain", "brain"]}, {"organ": ["lung"]}, {"organ": []}],
+        "organ",
+    )
+    assert values == ["brain", "lung"]
+
+
+def test_hca_project_matches_metadata_terms():
+    project = fixture_project()
+    assert database._hca_project_matches(project, ["brain", "mice"])
+    assert database._hca_project_matches(project, ["mus", "musculus"])
+    assert database._hca_project_matches(project, ["cortex"])
+    assert not database._hca_project_matches(project, ["retina"])
+
+
+def test_format_hca_project_returns_metadata_summary():
+    output = database._format_hca_project(fixture_project())
+    assert "Project: 1.3 Million Brain Cells from E18 Mice" in output
+    assert "Project ID: 74b6d569-3b11-42ef-b6b1-a0454522b4a0" in output
+    assert "Short Name: 1M Neurons" in output
+    assert "Data Use Restriction: NRES" in output
+    assert "Organs: brain" in output
+    assert "Organ Parts: cortex" in output
+    assert "Species: Mus musculus" in output
+    assert "Diseases: normal" in output
+    assert "Library Methods: 10x 3' v2" in output
+    assert "Total Cells: 1330000" in output
+    assert "File Types: fastq (16377), h5 (1)" in output
+
+
+def test_search_hca_projects_calls_public_endpoint():
+    session = Mock()
+    session.get.return_value = Response(fixture_payload())
+    projects = database._search_hca_projects("brain mice", max_results=1, session=session)
+    assert len(projects) == 1
+    session.get.assert_called_once_with(
+        "https://service.azul.data.humancellatlas.org/index/projects",
+        params={"size": 10},
+        timeout=30,
+    )
+
+
+def test_query_human_cell_atlas_projects_returns_formatted_result(monkeypatch):
+    monkeypatch.setattr(database, "_search_hca_projects", lambda query, max_results=5: [fixture_project()])
+    result = database.query_human_cell_atlas_projects("brain mice", max_results=1)
+    assert "Project: 1.3 Million Brain Cells from E18 Mice" in result
+    assert "Total Cells: 1330000" in result
+
+
+def test_query_human_cell_atlas_projects_returns_no_results_message(monkeypatch):
+    monkeypatch.setattr(database, "_search_hca_projects", lambda query, max_results=5: [])
+    result = database.query_human_cell_atlas_projects("missing")
+    assert result == "No Human Cell Atlas projects found."
+
+
+def test_query_human_cell_atlas_projects_rejects_empty_query():
+    result = database.query_human_cell_atlas_projects("   ")
+    assert result == "Error querying Human Cell Atlas: Query must not be empty."
+
+
+def test_query_human_cell_atlas_projects_returns_error_string_on_http_error(monkeypatch):
+    def raise_error(query, max_results=5):
+        raise requests.HTTPError("500 Server Error")
+
+    monkeypatch.setattr(database, "_search_hca_projects", raise_error)
+    result = database.query_human_cell_atlas_projects("brain")
+    assert result == "Error querying Human Cell Atlas: 500 Server Error"
+
+
+def test_human_cell_atlas_tool_description_is_registered():
+    names = {entry["name"] for entry in database_description.description}
+    assert "query_human_cell_atlas_projects" in names


### PR DESCRIPTION
This PR adds a new A1-visible database tool for public Human Cell Atlas project metadata lookup.

Changes:

adds `query_human_cell_atlas_projects` to `biomni/tool/database.py`
adds the matching tool description entry in `biomni/tool/tool_description/database.py`
adds focused fixture-backed tests in `tests/test_human_cell_atlas_projects.py`
adds a reduced public HCA Azul project fixture in `tests/fixtures/hca_brain_project.json`

`query_human_cell_atlas_projects` accepts a metadata query string and optional `max_results`, queries the public Human Cell Atlas Azul projects endpoint, filters project/sample/donor/protocol metadata locally, and returns formatted project summaries.

Testing
Focused tests and lint passed:

```bash
python -m pytest tests/test_human_cell_atlas_projects.py
python -m ruff check biomni/tool/database.py biomni/tool/tool_description/database.py tests/test_human_cell_atlas_projects.py
```

Result:

```text
10 passed
All checks passed!
```

Manual Live Prompt Validation
Manual local-LLM prompt validation passed against the local OpenAI-compatible Qwen endpoint with A1 tool retrieval enabled.

Prompt:

```text
Use Python to import the Biomni database tool exactly as follows: from biomni.tool.database import query_human_cell_atlas_projects. Then call query_human_cell_atlas_projects('brain mice', max_results=1) exactly once and print the result. After the observation, respond with a <solution> that reports the project title, project ID, data use restriction, organs, species, library methods, total cells, and file types. If the observation is an error, report the exact error in the <solution>.
```

Result:

A1 selected `query_human_cell_atlas_projects`
A1 generated an `<execute>` block
The tool queried live Human Cell Atlas Azul metadata
A1 completed with a `<solution>`

Observed tool output:

```text
Project: 1.3 Million Brain Cells from E18 Mice
Project ID: 74b6d569-3b11-42ef-b6b1-a0454522b4a0
Short Name: 1M Neurons
Portal URL: https://data.humancellatlas.org/explore/projects/74b6d569-3b11-42ef-b6b1-a0454522b4a0
Data Use Restriction: NRES
Organs: brain
Organ Parts: cortex
Species: Mus musculus
Diseases: normal
Library Methods: 10x 3' v2
Total Cells: 1330000
File Types: fastq (16377), h5 (1)
```

Notes
This follows Biomni's legacy database-tool pattern: the implementation is added directly to `biomni/tool/database.py`, the A1-visible description is added directly to `biomni/tool/tool_description/database.py`, and tests use a local fixture with a mocked response.

This PR implements public project metadata lookup only. It does not download controlled data or expression matrices, and it preserves the HCA data-use restriction field in the formatted output.