### PR TITLE
Add HuBMAP dataset database tool

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -445,6 +445,121 @@ def _format_query_results(result, options=None):
     return formatted
 
 
+def _extract_hubmap_dataset_hits(payload: dict) -> list[dict]:
+    hits = payload.get("hits", {}).get("hits", [])
+    if isinstance(hits, list):
+        return [hit.get("_source", hit) for hit in hits if isinstance(hit, dict)]
+    return []
+
+
+def _get_hubmap_values(value) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if item]
+    if value:
+        return [str(value)]
+    return []
+
+
+def _hubmap_dataset_matches(dataset: dict, terms: list[str]) -> bool:
+    if not terms:
+        return True
+
+    searchable_parts = [
+        dataset.get("title", ""),
+        dataset.get("hubmap_id", ""),
+        dataset.get("uuid", ""),
+        dataset.get("dataset_type", ""),
+        dataset.get("raw_dataset_type", ""),
+        dataset.get("group_name", ""),
+        dataset.get("status", ""),
+        dataset.get("data_access_level", ""),
+        dataset.get("assay_modality", ""),
+        dataset.get("pipeline", ""),
+    ]
+    searchable_parts.extend(_get_hubmap_values(dataset.get("assay_display_name")))
+    searchable_parts.extend(_get_hubmap_values(dataset.get("origin_samples_unique_mapped_organs")))
+    for sample in dataset.get("origin_samples", []):
+        if isinstance(sample, dict):
+            searchable_parts.extend(_get_hubmap_values(sample.get("mapped_organ")))
+            searchable_parts.extend(_get_hubmap_values(sample.get("organ")))
+            searchable_parts.extend(_get_hubmap_values(sample.get("sample_category")))
+    searchable_text = " ".join(searchable_parts).lower()
+    return all(term in searchable_text for term in terms)
+
+
+def _format_hubmap_dataset(dataset: dict) -> str:
+    title = dataset.get("title") or "N/A"
+    hubmap_id = dataset.get("hubmap_id") or "N/A"
+    uuid = dataset.get("uuid") or "N/A"
+    dataset_type = dataset.get("dataset_type") or dataset.get("raw_dataset_type") or "N/A"
+    assay = ", ".join(_get_hubmap_values(dataset.get("assay_display_name"))) or dataset_type
+    organ = ", ".join(_get_hubmap_values(dataset.get("origin_samples_unique_mapped_organs"))) or "N/A"
+    group_name = dataset.get("group_name") or "N/A"
+    status = dataset.get("status") or dataset.get("mapped_status") or "N/A"
+    access_level = dataset.get("data_access_level") or dataset.get("mapped_data_access_level") or "N/A"
+    is_spatial = dataset.get("is_spatial")
+    spatial_text = "Yes" if is_spatial is True else "No" if is_spatial is False else "N/A"
+    files = dataset.get("files", [])
+    file_count = len(files) if isinstance(files, list) else "N/A"
+    portal_url = f"https://portal.hubmapconsortium.org/browse/dataset/{uuid}" if uuid != "N/A" else "N/A"
+    return (
+        f"Dataset: {title}\n"
+        f"HuBMAP ID: {hubmap_id}\n"
+        f"UUID: {uuid}\n"
+        f"Portal URL: {portal_url}\n"
+        f"Dataset Type: {dataset_type}\n"
+        f"Assay: {assay}\n"
+        f"Organ: {organ}\n"
+        f"Group: {group_name}\n"
+        f"Status: {status}\n"
+        f"Data Access Level: {access_level}\n"
+        f"Spatial: {spatial_text}\n"
+        f"File Count: {file_count}"
+    )
+
+
+def _search_hubmap_datasets(query: str, max_results: int = 5, session: requests.Session | None = None) -> list[dict]:
+    active_session = session or requests.Session()
+    response = active_session.post(
+        "https://search.api.hubmapconsortium.org/v3/portal/search",
+        json={"query": {"bool": {"filter": [{"term": {"entity_type.keyword": "Dataset"}}]}}, "size": 10},
+        timeout=30,
+    )
+    response.raise_for_status()
+    datasets = _extract_hubmap_dataset_hits(response.json())
+    terms = [term.lower() for term in query.split() if term.strip()]
+    return [dataset for dataset in datasets if _hubmap_dataset_matches(dataset, terms)][:max_results]
+
+
+def query_hubmap_datasets(query: str, max_results: int = 5) -> str:
+    """Query public HuBMAP dataset metadata.
+
+    Parameters
+    ----------
+    - query (str): The metadata query string, such as an organ, assay, group, or dataset title.
+    - max_results (int): The maximum number of matching datasets to return (default: 5).
+
+    Returns
+    -------
+    - str: The formatted HuBMAP dataset results or an error message.
+
+    """
+    try:
+        search_query = query.strip()
+        if not search_query:
+            return "Error querying HuBMAP: Query must not be empty."
+
+        result_count = max(1, int(max_results))
+        datasets = _search_hubmap_datasets(search_query, max_results=result_count)
+        if datasets:
+            return "\n\n".join(_format_hubmap_dataset(dataset) for dataset in datasets)
+        return "No HuBMAP datasets found."
+    except requests.RequestException as e:
+        return f"Error querying HuBMAP: {e}"
+    except ValueError as e:
+        return f"Error querying HuBMAP: {e}"
+
+
 def query_uniprot(
     prompt=None,
     endpoint=None,

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -1,5 +1,25 @@
 description = [
     {
+        "description": "Query public HuBMAP dataset metadata.",
+        "name": "query_hubmap_datasets",
+        "optional_parameters": [
+            {
+                "default": 5,
+                "description": "The maximum number of matching datasets to return.",
+                "name": "max_results",
+                "type": "int",
+            }
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "The metadata query string, such as an organ, assay, group, or dataset title.",
+                "name": "query",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Query the UniProt REST API using either natural language or a direct endpoint.",
         "name": "query_uniprot",
         "optional_parameters": [

--- a/tests/fixtures/hubmap_ovary_dataset.json
+++ b/tests/fixtures/hubmap_ovary_dataset.json
@@ -1,0 +1,63 @@
+{
+  "attribution": {
+    "provider": "HuBMAP",
+    "source_url": "https://search.api.hubmapconsortium.org/v3/portal/search",
+    "retrieved_date": "2026-09-08",
+    "note": "Public HuBMAP portal search response reduced to one dataset."
+  },
+  "response": {
+    "hits": {
+      "hits": [
+        {
+          "_id": "ba4753cba9dcb01d54185d737df9022c",
+          "_source": {
+            "assay_display_name": [
+              "10X Multiome [Salmon + ArchR + Muon]"
+            ],
+            "assay_modality": "multiple",
+            "data_access_level": "public",
+            "dataset_type": "10X Multiome [Salmon + ArchR + Muon]",
+            "entity_type": "Dataset",
+            "files": [
+              {
+                "description": "Normalized gene expression with additional metadata",
+                "rel_path": "hubmap_ui/mudata-zarr/secondary_analysis.zarr/.zattrs",
+                "size": 138,
+                "type": "unknown"
+              },
+              {
+                "description": "RNA matrix data",
+                "rel_path": "hubmap_ui/mudata-zarr/secondary_analysis.zarr/.zgroup",
+                "size": 24,
+                "type": "unknown"
+              }
+            ],
+            "group_name": "TMC - University of Pennsylvania",
+            "hubmap_id": "HBM522.GTLH.372",
+            "is_spatial": true,
+            "mapped_data_access_level": "Public",
+            "mapped_status": "Published",
+            "origin_samples": [
+              {
+                "entity_type": "Sample",
+                "hubmap_id": "HBM245.DLGF.454",
+                "mapped_organ": "Ovary (Left)",
+                "organ": "LO",
+                "sample_category": "organ",
+                "uuid": "d9db7bc957aea7da62fd2417b986e1e4"
+              }
+            ],
+            "origin_samples_unique_mapped_organs": [
+              "Ovary (Left)"
+            ],
+            "pipeline": "Salmon + ArchR + Muon",
+            "raw_dataset_type": "10X Multiome",
+            "status": "Published",
+            "title": "10X Multiome [Salmon + ArchR + Muon] data from the ovary (left) of a 19-year-old white female",
+            "uuid": "ba4753cba9dcb01d54185d737df9022c"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/hubmap_ovary_dataset.json
+++ b/tests/fixtures/hubmap_ovary_dataset.json
@@ -1,63 +1,59 @@
 {
-  "attribution": {
-    "provider": "HuBMAP",
-    "source_url": "https://search.api.hubmapconsortium.org/v3/portal/search",
-    "retrieved_date": "2026-09-08",
-    "note": "Public HuBMAP portal search response reduced to one dataset."
-  },
-  "response": {
-    "hits": {
-      "hits": [
-        {
-          "_id": "ba4753cba9dcb01d54185d737df9022c",
-          "_source": {
-            "assay_display_name": [
-              "10X Multiome [Salmon + ArchR + Muon]"
-            ],
-            "assay_modality": "multiple",
-            "data_access_level": "public",
-            "dataset_type": "10X Multiome [Salmon + ArchR + Muon]",
-            "entity_type": "Dataset",
-            "files": [
-              {
-                "description": "Normalized gene expression with additional metadata",
-                "rel_path": "hubmap_ui/mudata-zarr/secondary_analysis.zarr/.zattrs",
-                "size": 138,
-                "type": "unknown"
-              },
-              {
-                "description": "RNA matrix data",
-                "rel_path": "hubmap_ui/mudata-zarr/secondary_analysis.zarr/.zgroup",
-                "size": 24,
-                "type": "unknown"
-              }
-            ],
-            "group_name": "TMC - University of Pennsylvania",
-            "hubmap_id": "HBM522.GTLH.372",
-            "is_spatial": true,
-            "mapped_data_access_level": "Public",
-            "mapped_status": "Published",
-            "origin_samples": [
-              {
-                "entity_type": "Sample",
-                "hubmap_id": "HBM245.DLGF.454",
-                "mapped_organ": "Ovary (Left)",
-                "organ": "LO",
-                "sample_category": "organ",
-                "uuid": "d9db7bc957aea7da62fd2417b986e1e4"
-              }
-            ],
-            "origin_samples_unique_mapped_organs": [
-              "Ovary (Left)"
-            ],
-            "pipeline": "Salmon + ArchR + Muon",
-            "raw_dataset_type": "10X Multiome",
-            "status": "Published",
-            "title": "10X Multiome [Salmon + ArchR + Muon] data from the ovary (left) of a 19-year-old white female",
-            "uuid": "ba4753cba9dcb01d54185d737df9022c"
-          }
-        }
-      ]
-    }
-  }
+	"attribution": {
+		"provider": "HuBMAP",
+		"source_url": "https://search.api.hubmapconsortium.org/v3/portal/search",
+		"retrieved_date": "2026-09-08",
+		"note": "Public HuBMAP portal search response reduced to one dataset."
+	},
+	"response": {
+		"hits": {
+			"hits": [
+				{
+					"_id": "ba4753cba9dcb01d54185d737df9022c",
+					"_source": {
+						"assay_display_name": ["10X Multiome [Salmon + ArchR + Muon]"],
+						"assay_modality": "multiple",
+						"data_access_level": "public",
+						"dataset_type": "10X Multiome [Salmon + ArchR + Muon]",
+						"entity_type": "Dataset",
+						"files": [
+							{
+								"description": "Normalized gene expression with additional metadata",
+								"rel_path": "hubmap_ui/mudata-zarr/secondary_analysis.zarr/.zattrs",
+								"size": 138,
+								"type": "unknown"
+							},
+							{
+								"description": "RNA matrix data",
+								"rel_path": "hubmap_ui/mudata-zarr/secondary_analysis.zarr/.zgroup",
+								"size": 24,
+								"type": "unknown"
+							}
+						],
+						"group_name": "TMC - University of Pennsylvania",
+						"hubmap_id": "HBM522.GTLH.372",
+						"is_spatial": true,
+						"mapped_data_access_level": "Public",
+						"mapped_status": "Published",
+						"origin_samples": [
+							{
+								"entity_type": "Sample",
+								"hubmap_id": "HBM245.DLGF.454",
+								"mapped_organ": "Ovary (Left)",
+								"organ": "LO",
+								"sample_category": "organ",
+								"uuid": "d9db7bc957aea7da62fd2417b986e1e4"
+							}
+						],
+						"origin_samples_unique_mapped_organs": ["Ovary (Left)"],
+						"pipeline": "Salmon + ArchR + Muon",
+						"raw_dataset_type": "10X Multiome",
+						"status": "Published",
+						"title": "10X Multiome [Salmon + ArchR + Muon] data from the ovary (left) of a 19-year-old white female",
+						"uuid": "ba4753cba9dcb01d54185d737df9022c"
+					}
+				}
+			]
+		}
+	}
 }

--- a/tests/test_hubmap_datasets.py
+++ b/tests/test_hubmap_datasets.py
@@ -1,0 +1,109 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+from biomni.tool import database
+from biomni.tool.tool_description import database as database_description
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload():
+    return json.loads((FIXTURES_DIR / "hubmap_ovary_dataset.json").read_text(encoding="utf-8"))["response"]
+
+
+def fixture_dataset():
+    return fixture_payload()["hits"]["hits"][0]["_source"]
+
+
+def test_extract_hubmap_dataset_hits_returns_sources():
+    datasets = database._extract_hubmap_dataset_hits(fixture_payload())
+    assert len(datasets) == 1
+    assert datasets[0]["hubmap_id"] == "HBM522.GTLH.372"
+
+
+def test_get_hubmap_values_handles_lists_and_scalars():
+    assert database._get_hubmap_values(["ovary", None, "kidney"]) == ["ovary", "kidney"]
+    assert database._get_hubmap_values("public") == ["public"]
+    assert database._get_hubmap_values(None) == []
+
+
+def test_hubmap_dataset_matches_metadata_terms():
+    dataset = fixture_dataset()
+    assert database._hubmap_dataset_matches(dataset, ["ovary"])
+    assert database._hubmap_dataset_matches(dataset, ["10x", "multiome"])
+    assert database._hubmap_dataset_matches(dataset, ["pennsylvania"])
+    assert not database._hubmap_dataset_matches(dataset, ["kidney"])
+
+
+def test_format_hubmap_dataset_returns_metadata_summary():
+    output = database._format_hubmap_dataset(fixture_dataset())
+    assert "Dataset: 10X Multiome [Salmon + ArchR + Muon] data from the ovary" in output
+    assert "HuBMAP ID: HBM522.GTLH.372" in output
+    assert "UUID: ba4753cba9dcb01d54185d737df9022c" in output
+    assert "Dataset Type: 10X Multiome [Salmon + ArchR + Muon]" in output
+    assert "Organ: Ovary (Left)" in output
+    assert "Group: TMC - University of Pennsylvania" in output
+    assert "Data Access Level: public" in output
+    assert "Spatial: Yes" in output
+    assert "File Count: 2" in output
+
+
+def test_search_hubmap_datasets_calls_public_endpoint():
+    session = Mock()
+    session.post.return_value = Response(fixture_payload())
+    datasets = database._search_hubmap_datasets("ovary multiome", max_results=1, session=session)
+    assert len(datasets) == 1
+    session.post.assert_called_once_with(
+        "https://search.api.hubmapconsortium.org/v3/portal/search",
+        json={"query": {"bool": {"filter": [{"term": {"entity_type.keyword": "Dataset"}}]}}, "size": 10},
+        timeout=30,
+    )
+
+
+def test_query_hubmap_datasets_returns_formatted_result(monkeypatch):
+    monkeypatch.setattr(database, "_search_hubmap_datasets", lambda query, max_results=5: [fixture_dataset()])
+    result = database.query_hubmap_datasets("ovary multiome", max_results=1)
+    assert "HuBMAP ID: HBM522.GTLH.372" in result
+    assert "Organ: Ovary (Left)" in result
+
+
+def test_query_hubmap_datasets_returns_no_results_message(monkeypatch):
+    monkeypatch.setattr(database, "_search_hubmap_datasets", lambda query, max_results=5: [])
+    result = database.query_hubmap_datasets("missing")
+    assert result == "No HuBMAP datasets found."
+
+
+def test_query_hubmap_datasets_rejects_empty_query():
+    result = database.query_hubmap_datasets("   ")
+    assert result == "Error querying HuBMAP: Query must not be empty."
+
+
+def test_query_hubmap_datasets_returns_error_string_on_http_error(monkeypatch):
+    def raise_error(query, max_results=5):
+        raise requests.HTTPError("500 Server Error")
+
+    monkeypatch.setattr(database, "_search_hubmap_datasets", raise_error)
+    result = database.query_hubmap_datasets("ovary")
+    assert result == "Error querying HuBMAP: 500 Server Error"
+
+
+def test_hubmap_tool_description_is_registered():
+    names = {entry["name"] for entry in database_description.description}
+    assert "query_hubmap_datasets" in names


### PR DESCRIPTION
This PR adds a new A1-visible database tool for public HuBMAP dataset metadata lookup.

Changes:

adds `query_hubmap_datasets` to `biomni/tool/database.py`
adds the matching tool description entry in `biomni/tool/tool_description/database.py`
adds focused fixture-backed tests in `tests/test_hubmap_datasets.py`
adds a reduced public HuBMAP portal search fixture in `tests/fixtures/hubmap_ovary_dataset.json`

`query_hubmap_datasets` accepts a metadata query string and optional `max_results`, queries the public HuBMAP portal search endpoint for datasets, filters common dataset/sample metadata locally, and returns formatted dataset summaries.

Testing
Focused tests and lint passed:

```bash
python -m pytest tests/test_hubmap_datasets.py
python -m ruff check biomni/tool/database.py biomni/tool/tool_description/database.py tests/test_hubmap_datasets.py
```

Result:

```text
10 passed
All checks passed!
```

Manual Live Prompt Validation
Manual local-LLM prompt validation passed against the local OpenAI-compatible Qwen endpoint with A1 tool retrieval enabled.

Prompt:

```text
Use Python to import the Biomni database tool exactly as follows: from biomni.tool.database import query_hubmap_datasets. Then call query_hubmap_datasets('ovary multiome', max_results=1) exactly once and print the result. After the observation, respond with a <solution> that reports the dataset title, HuBMAP ID, UUID, dataset type, assay, organ, group, status, data access level, spatial flag, and file count. If the observation is an error, report the exact error in the <solution>.
```

Result:

A1 selected `query_hubmap_datasets`
A1 generated an `<execute>` block
The tool queried live HuBMAP portal search metadata
A1 completed with a `<solution>`

Observed tool output:

```text
Dataset: 10X Multiome [Salmon + ArchR + Muon] data from the ovary (left) of a 19-year-old white female
HuBMAP ID: HBM522.GTLH.372
UUID: ba4753cba9dcb01d54185d737df9022c
Portal URL: https://portal.hubmapconsortium.org/browse/dataset/ba4753cba9dcb01d54185d737df9022c
Dataset Type: 10X Multiome [Salmon + ArchR + Muon]
Assay: 10X Multiome [Salmon + ArchR + Muon]
Organ: Ovary (Left)
Group: TMC - University of Pennsylvania
Status: Published
Data Access Level: public
Spatial: Yes
File Count: 11544
```

Notes
This follows Biomni's legacy database-tool pattern: the implementation is added directly to `biomni/tool/database.py`, the A1-visible description is added directly to `biomni/tool/tool_description/database.py`, and tests use a local fixture with a mocked response.

This PR implements public dataset metadata lookup only. It does not download data files or access controlled HuBMAP content.