### PR TITLE
fix(eval): normalize patient gene symbols before scoring

### DIFF
--- a/biomni/eval/biomni_eval1.py
+++ b/biomni/eval/biomni_eval1.py
@@ -140,10 +140,8 @@ class BiomniEval1:
                     predicted_genes = [predicted_genes]
 
                 # Get ground truth genes (stored as comma-separated or single)
-                if "," in ground_truth:
-                    true_genes = [g.strip() for g in ground_truth.split(",")]
-                else:
-                    true_genes = [ground_truth]
+                true_genes = [gene.strip().upper() for gene in ground_truth.split(",")]
+                predicted_genes = [str(gene).strip().upper() for gene in predicted_genes]
 
                 # Check for intersection
                 if predicted_genes and set(true_genes) & set(predicted_genes):

--- a/tests/test_biomni_eval1.py
+++ b/tests/test_biomni_eval1.py
@@ -1,0 +1,15 @@
+from biomni.eval.biomni_eval1 import BiomniEval1
+
+
+def test_patient_gene_detection_normalizes_gene_symbol_case():
+    evaluator = object.__new__(BiomniEval1)
+
+    assert evaluator._compute_reward(
+        "patient_gene_detection", '{"causal_gene": [" brca1 "]}', "BRCA1, TP53"
+    ) == 1.0
+
+
+def test_patient_gene_detection_keeps_nonmatching_gene_incorrect():
+    evaluator = object.__new__(BiomniEval1)
+
+    assert evaluator._compute_reward("patient_gene_detection", '{"causal_gene": ["EGFR"]}', "BRCA1") == 0.0

--- a/tests/test_biomni_eval1.py
+++ b/tests/test_biomni_eval1.py
@@ -4,9 +4,7 @@ from biomni.eval.biomni_eval1 import BiomniEval1
 def test_patient_gene_detection_normalizes_gene_symbol_case():
     evaluator = object.__new__(BiomniEval1)
 
-    assert evaluator._compute_reward(
-        "patient_gene_detection", '{"causal_gene": [" brca1 "]}', "BRCA1, TP53"
-    ) == 1.0
+    assert evaluator._compute_reward("patient_gene_detection", '{"causal_gene": [" brca1 "]}', "BRCA1, TP53") == 1.0
 
 
 def test_patient_gene_detection_keeps_nonmatching_gene_incorrect():


### PR DESCRIPTION
Normalize predicted and reference patient gene symbols before set comparison, matching the case-insensitive behavior of the adjacent gene scorer. Nonmatching genes still receive zero reward.

## Validation
- `python -m pytest tests/test_biomni_eval1.py -q`: 2 passed
- `git diff --check && python -m py_compile biomni/eval/biomni_eval1.py`: passed