### PR TITLE
fix(retriever): ignore invalid model-selected indices

### DIFF
--- a/biomni/model/retriever.py
+++ b/biomni/model/retriever.py
@@ -107,17 +107,19 @@ IMPORTANT GUIDELINES:
         # Get the selected resources
         selected_resources = {
             "tools": [
-                resources["tools"][i] for i in selected_indices.get("tools", []) if i < len(resources.get("tools", []))
+                resources["tools"][i]
+                for i in selected_indices.get("tools", [])
+                if 0 <= i < len(resources.get("tools", []))
             ],
             "data_lake": [
                 resources["data_lake"][i]
                 for i in selected_indices.get("data_lake", [])
-                if i < len(resources.get("data_lake", []))
+                if 0 <= i < len(resources.get("data_lake", []))
             ],
             "libraries": [
                 resources["libraries"][i]
                 for i in selected_indices.get("libraries", [])
-                if i < len(resources.get("libraries", []))
+                if 0 <= i < len(resources.get("libraries", []))
             ],
         }
 
@@ -126,7 +128,7 @@ IMPORTANT GUIDELINES:
             selected_resources["know_how"] = [
                 resources["know_how"][i]
                 for i in selected_indices.get("know_how", [])
-                if i < len(resources.get("know_how", []))
+                if 0 <= i < len(resources.get("know_how", []))
             ]
 
         return selected_resources
@@ -172,32 +174,28 @@ IMPORTANT GUIDELINES:
             response = str(response)
         selected_indices = {"tools": [], "data_lake": [], "libraries": [], "know_how": []}
 
+        def parse_indices(match):
+            """Return valid integer tokens without discarding adjacent selections."""
+            indices = []
+            if not match or not match.group(1).strip():
+                return indices
+            for token in match.group(1).split(","):
+                with contextlib.suppress(ValueError):
+                    indices.append(int(token.strip()))
+            return indices
+
         # Extract indices for each category
         tools_match = re.search(r"TOOLS:\s*\[(.*?)\]", response, re.IGNORECASE)
-        if tools_match and tools_match.group(1).strip():
-            with contextlib.suppress(ValueError):
-                selected_indices["tools"] = [int(idx.strip()) for idx in tools_match.group(1).split(",") if idx.strip()]
+        selected_indices["tools"] = parse_indices(tools_match)
 
         data_lake_match = re.search(r"DATA_LAKE:\s*\[(.*?)\]", response, re.IGNORECASE)
-        if data_lake_match and data_lake_match.group(1).strip():
-            with contextlib.suppress(ValueError):
-                selected_indices["data_lake"] = [
-                    int(idx.strip()) for idx in data_lake_match.group(1).split(",") if idx.strip()
-                ]
+        selected_indices["data_lake"] = parse_indices(data_lake_match)
 
         libraries_match = re.search(r"LIBRARIES:\s*\[(.*?)\]", response, re.IGNORECASE)
-        if libraries_match and libraries_match.group(1).strip():
-            with contextlib.suppress(ValueError):
-                selected_indices["libraries"] = [
-                    int(idx.strip()) for idx in libraries_match.group(1).split(",") if idx.strip()
-                ]
+        selected_indices["libraries"] = parse_indices(libraries_match)
 
         # Extract know-how indices
         know_how_match = re.search(r"KNOW[-_]HOW:\s*\[(.*?)\]", response, re.IGNORECASE)
-        if know_how_match and know_how_match.group(1).strip():
-            with contextlib.suppress(ValueError):
-                selected_indices["know_how"] = [
-                    int(idx.strip()) for idx in know_how_match.group(1).split(",") if idx.strip()
-                ]
+        selected_indices["know_how"] = parse_indices(know_how_match)
 
         return selected_indices

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -41,7 +41,12 @@ class _LLM:
 
 def test_retrieval_ignores_negative_and_out_of_range_indices(retriever_module):
     _Response.content = "TOOLS: [-1, 1, 9]\nDATA_LAKE: [-1, 0, 9]\nLIBRARIES: [-2, 1, 9]\nKNOW_HOW: [-3, 0, 9]"
-    resources = {"tools": ["first", "second"], "data_lake": ["lake"], "libraries": ["lib0", "lib1"], "know_how": ["guide"]}
+    resources = {
+        "tools": ["first", "second"],
+        "data_lake": ["lake"],
+        "libraries": ["lib0", "lib1"],
+        "know_how": ["guide"],
+    }
 
     assert retriever_module().prompt_based_retrieval("test", resources, llm=_LLM()) == {
         "tools": ["second"],

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,0 +1,51 @@
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def retriever_module(monkeypatch):
+    monkeypatch.delitem(sys.modules, "biomni.model.retriever", raising=False)
+    messages = types.ModuleType("langchain_core.messages")
+    messages.HumanMessage = lambda content: content
+    monkeypatch.setitem(sys.modules, "langchain_core", types.ModuleType("langchain_core"))
+    monkeypatch.setitem(sys.modules, "langchain_core.messages", messages)
+    openai = types.ModuleType("langchain_openai")
+    openai.ChatOpenAI = object
+    monkeypatch.setitem(sys.modules, "langchain_openai", openai)
+    from biomni.model.retriever import ToolRetriever
+
+    return ToolRetriever
+
+
+def test_parser_keeps_valid_indices_adjacent_to_malformed_token(retriever_module):
+    response = "TOOLS: [0, not-an-index, 2]\nDATA_LAKE: [1, nope]\nLIBRARIES: [2, bad]\nKNOW_HOW: [3, invalid]"
+
+    assert retriever_module()._parse_llm_response(response) == {
+        "tools": [0, 2],
+        "data_lake": [1],
+        "libraries": [2],
+        "know_how": [3],
+    }
+
+
+class _Response:
+    content = "TOOLS: [-1, 1]\nDATA_LAKE: []\nLIBRARIES: []"
+
+
+class _LLM:
+    def invoke(self, _messages):
+        return _Response()
+
+
+def test_retrieval_ignores_negative_and_out_of_range_indices(retriever_module):
+    _Response.content = "TOOLS: [-1, 1, 9]\nDATA_LAKE: [-1, 0, 9]\nLIBRARIES: [-2, 1, 9]\nKNOW_HOW: [-3, 0, 9]"
+    resources = {"tools": ["first", "second"], "data_lake": ["lake"], "libraries": ["lib0", "lib1"], "know_how": ["guide"]}
+
+    assert retriever_module().prompt_based_retrieval("test", resources, llm=_LLM()) == {
+        "tools": ["second"],
+        "data_lake": ["lake"],
+        "libraries": ["lib1"],
+        "know_how": ["guide"],
+    }


### PR DESCRIPTION
Ignore negative and out-of-range resource indices returned by the model, while keeping valid selections if another token is malformed. Apply the same bounds to tools, data lake, libraries and know-how. The tests isolate imported module stubs with pytest monkeypatch.

## Validation
- `python -m pytest tests/test_retriever.py -q`: 2 passed
- `git diff --check && python -m py_compile biomni/model/retriever.py`: passed