### PR TITLE
fix(know-how): preserve non-metadata markdown separators

### DIFF
--- a/biomni/know_how/loader.py
+++ b/biomni/know_how/loader.py
@@ -178,7 +178,7 @@ class KnowHowLoader:
         skip_until_separator = False
         found_first_h1 = False
 
-        for line in lines:
+        for line_index, line in enumerate(lines):
             # Track first H1 (title)
             if line.startswith("# ") and not found_first_h1:
                 result_lines.append(line)
@@ -193,9 +193,13 @@ class KnowHowLoader:
             # Skip separator lines before and after metadata
             if line.strip() == "---":
                 if not in_metadata:
-                    # This might be the separator before metadata
-                    skip_until_separator = True
-                    continue
+                    next_nonempty = next((candidate for candidate in lines[line_index + 1 :] if candidate.strip()), "")
+                    if next_nonempty.startswith("## Metadata"):
+                        # This is the separator before metadata.
+                        while result_lines and not result_lines[-1].strip():
+                            result_lines.pop()
+                        skip_until_separator = True
+                        continue
                 else:
                     # This is the separator after metadata
                     in_metadata = False

--- a/tests/test_know_how_loader.py
+++ b/tests/test_know_how_loader.py
@@ -8,8 +8,9 @@ def test_strip_metadata_preserves_non_metadata_horizontal_rules():
 
 
 def test_strip_metadata_removes_metadata_with_its_leading_separator():
-    content = (
-        "# Protocol\n\n---\n\n## Metadata\n\n**Authors**: Example\n\n---\n\n## Overview\n\nKeep this section.\n"
-    )
+    content = "# Protocol\n\n---\n\n## Metadata\n\n**Authors**: Example\n\n---\n\n## Overview\n\nKeep this section.\n"
 
-    assert KnowHowLoader._strip_metadata(object.__new__(KnowHowLoader), content) == "# Protocol\n\n## Overview\n\nKeep this section."
+    assert (
+        KnowHowLoader._strip_metadata(object.__new__(KnowHowLoader), content)
+        == "# Protocol\n\n## Overview\n\nKeep this section."
+    )

--- a/tests/test_know_how_loader.py
+++ b/tests/test_know_how_loader.py
@@ -1,0 +1,15 @@
+from biomni.know_how.loader import KnowHowLoader
+
+
+def test_strip_metadata_preserves_non_metadata_horizontal_rules():
+    content = "# Protocol\n\nIntro\n\n---\n\n## Overview\n\nKeep this section.\n"
+
+    assert KnowHowLoader._strip_metadata(object.__new__(KnowHowLoader), content) == content.strip()
+
+
+def test_strip_metadata_removes_metadata_with_its_leading_separator():
+    content = (
+        "# Protocol\n\n---\n\n## Metadata\n\n**Authors**: Example\n\n---\n\n## Overview\n\nKeep this section.\n"
+    )
+
+    assert KnowHowLoader._strip_metadata(object.__new__(KnowHowLoader), content) == "# Protocol\n\n## Overview\n\nKeep this section."


### PR DESCRIPTION
Preserve ordinary Markdown separators and the following knowledge text when stripping know-how metadata. Skip a separator only when the next non-empty line identifies a Metadata section.

## Validation
- `python -m pytest tests/test_know_how_loader.py -q`: 2 passed
- `git diff --check && python -m py_compile biomni/know_how/loader.py`: passed