### PR TITLE
Add AlphaFold bulk metadata database tool

### DIFF
--- a/biomni/tool/database.py
+++ b/biomni/tool/database.py
@@ -690,6 +690,96 @@ def query_alphafold(
         }
 
 
+def _normalize_alphafold_uniprot_ids(uniprot_ids) -> list[str]:
+    if isinstance(uniprot_ids, str):
+        raw_ids = uniprot_ids.replace("\n", ",").split(",")
+    else:
+        raw_ids = list(uniprot_ids or [])
+    return [str(uniprot_id).strip() for uniprot_id in raw_ids if str(uniprot_id).strip()]
+
+
+def _extract_alphafold_prediction_record(payload) -> dict:
+    if isinstance(payload, list) and payload and isinstance(payload[0], dict):
+        return payload[0]
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def _format_alphafold_bulk_record(uniprot_id: str, record: dict) -> str:
+    if not record:
+        return f"UniProt ID: {uniprot_id}\nStatus: No AlphaFold prediction found."
+
+    accession = record.get("uniprotAccession") or uniprot_id
+    entry_id = record.get("entryId") or record.get("modelEntityId") or "N/A"
+    gene = record.get("gene") or "N/A"
+    description = record.get("uniprotDescription") or "N/A"
+    organism = record.get("organismScientificName") or "N/A"
+    sequence_range = f"{record.get('sequenceStart', 'N/A')}-{record.get('sequenceEnd', 'N/A')}"
+    latest_version = record.get("latestVersion") or "N/A"
+    model_date = record.get("modelCreatedDate") or "N/A"
+    checksum = record.get("sequenceChecksum") or "N/A"
+    confidence = record.get("globalMetricValue")
+    confidence_text = str(confidence) if confidence is not None else "N/A"
+    return (
+        f"UniProt ID: {accession}\n"
+        f"Entry ID: {entry_id}\n"
+        f"Gene: {gene}\n"
+        f"Description: {description}\n"
+        f"Organism: {organism}\n"
+        f"Sequence Range: {sequence_range}\n"
+        f"Latest Version: {latest_version}\n"
+        f"Model Created: {model_date}\n"
+        f"Sequence Checksum: {checksum}\n"
+        f"Mean pLDDT: {confidence_text}\n"
+        f"PDB URL: {record.get('pdbUrl') or 'N/A'}\n"
+        f"CIF URL: {record.get('cifUrl') or 'N/A'}\n"
+        f"PAE JSON URL: {record.get('paeDocUrl') or 'N/A'}"
+    )
+
+
+def _search_alphafold_bulk_metadata(uniprot_ids, session: requests.Session | None = None) -> list[tuple[str, dict]]:
+    active_session = session or requests.Session()
+    records = []
+    for uniprot_id in _normalize_alphafold_uniprot_ids(uniprot_ids):
+        response = active_session.get(f"https://alphafold.ebi.ac.uk/api/prediction/{uniprot_id}", timeout=30)
+        if response.status_code == 404:
+            records.append((uniprot_id, {}))
+            continue
+        response.raise_for_status()
+        records.append((uniprot_id, _extract_alphafold_prediction_record(response.json())))
+    return records
+
+
+def query_alphafold_bulk_metadata(uniprot_ids, max_results: int = 10) -> str:
+    """Query AlphaFold DB prediction metadata for multiple UniProt accessions.
+
+    Parameters
+    ----------
+    - uniprot_ids: A comma-separated string or list of UniProt accessions.
+    - max_results (int): The maximum number of accessions to query (default: 10).
+
+    Returns
+    -------
+    - str: The formatted AlphaFold metadata results or an error message.
+
+    """
+    try:
+        normalized_ids = _normalize_alphafold_uniprot_ids(uniprot_ids)
+        if not normalized_ids:
+            return "Error querying AlphaFold bulk metadata: UniProt IDs must not be empty."
+
+        result_count = max(1, int(max_results))
+        records = _search_alphafold_bulk_metadata(normalized_ids[:result_count])
+        if records:
+            return "\n\n".join(_format_alphafold_bulk_record(uniprot_id, record) for uniprot_id, record in records)
+        return "No AlphaFold metadata found."
+    except requests.RequestException as e:
+        return f"Error querying AlphaFold bulk metadata: {e}"
+    except ValueError as e:
+        return f"Error querying AlphaFold bulk metadata: {e}"
+
+
 def query_interpro(
     prompt=None,
     endpoint=None,

--- a/biomni/tool/tool_description/database.py
+++ b/biomni/tool/tool_description/database.py
@@ -52,6 +52,26 @@ description = [
         ],
     },
     {
+        "description": "Query AlphaFold DB prediction metadata for multiple UniProt accessions.",
+        "name": "query_alphafold_bulk_metadata",
+        "optional_parameters": [
+            {
+                "default": 10,
+                "description": "The maximum number of accessions to query.",
+                "name": "max_results",
+                "type": "int",
+            }
+        ],
+        "required_parameters": [
+            {
+                "default": None,
+                "description": "A comma-separated string or list of UniProt accessions.",
+                "name": "uniprot_ids",
+                "type": "str",
+            }
+        ],
+    },
+    {
         "description": "Query the InterPro REST API using natural language or a direct endpoint.",
         "name": "query_interpro",
         "optional_parameters": [

--- a/tests/fixtures/alphafold_p69905_prediction.json
+++ b/tests/fixtures/alphafold_p69905_prediction.json
@@ -1,0 +1,31 @@
+{
+  "attribution": {
+    "provider": "AlphaFold Protein Structure Database",
+    "source_url": "https://alphafold.ebi.ac.uk/api/prediction/P69905",
+    "retrieved_date": "2026-09-10",
+    "note": "Public AlphaFold DB prediction response reduced to fields covered by this tool."
+  },
+  "response": [
+    {
+      "toolUsed": "AlphaFold Monomer v2.0 pipeline",
+      "providerId": "GDM",
+      "entityType": "protein",
+      "modelEntityId": "AF-P69905-F1",
+      "modelCreatedDate": "2025-08-01T00:00:00Z",
+      "globalMetricValue": 98.06,
+      "latestVersion": 6,
+      "sequenceStart": 1,
+      "sequenceEnd": 142,
+      "sequenceChecksum": "6077c452d1dc6151040b2b179e2294c7",
+      "gene": "HBA1",
+      "uniprotAccession": "P69905",
+      "uniprotId": "HBA_HUMAN",
+      "uniprotDescription": "Hemoglobin subunit alpha",
+      "organismScientificName": "Homo sapiens",
+      "entryId": "AF-P69905-F1",
+      "pdbUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.pdb",
+      "cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.cif",
+      "paeDocUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-predicted_aligned_error_v6.json"
+    }
+  ]
+}

--- a/tests/fixtures/alphafold_p69905_prediction.json
+++ b/tests/fixtures/alphafold_p69905_prediction.json
@@ -1,31 +1,31 @@
 {
-  "attribution": {
-    "provider": "AlphaFold Protein Structure Database",
-    "source_url": "https://alphafold.ebi.ac.uk/api/prediction/P69905",
-    "retrieved_date": "2026-09-10",
-    "note": "Public AlphaFold DB prediction response reduced to fields covered by this tool."
-  },
-  "response": [
-    {
-      "toolUsed": "AlphaFold Monomer v2.0 pipeline",
-      "providerId": "GDM",
-      "entityType": "protein",
-      "modelEntityId": "AF-P69905-F1",
-      "modelCreatedDate": "2025-08-01T00:00:00Z",
-      "globalMetricValue": 98.06,
-      "latestVersion": 6,
-      "sequenceStart": 1,
-      "sequenceEnd": 142,
-      "sequenceChecksum": "6077c452d1dc6151040b2b179e2294c7",
-      "gene": "HBA1",
-      "uniprotAccession": "P69905",
-      "uniprotId": "HBA_HUMAN",
-      "uniprotDescription": "Hemoglobin subunit alpha",
-      "organismScientificName": "Homo sapiens",
-      "entryId": "AF-P69905-F1",
-      "pdbUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.pdb",
-      "cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.cif",
-      "paeDocUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-predicted_aligned_error_v6.json"
-    }
-  ]
+	"attribution": {
+		"provider": "AlphaFold Protein Structure Database",
+		"source_url": "https://alphafold.ebi.ac.uk/api/prediction/P69905",
+		"retrieved_date": "2026-09-10",
+		"note": "Public AlphaFold DB prediction response reduced to fields covered by this tool."
+	},
+	"response": [
+		{
+			"toolUsed": "AlphaFold Monomer v2.0 pipeline",
+			"providerId": "GDM",
+			"entityType": "protein",
+			"modelEntityId": "AF-P69905-F1",
+			"modelCreatedDate": "2025-08-01T00:00:00Z",
+			"globalMetricValue": 98.06,
+			"latestVersion": 6,
+			"sequenceStart": 1,
+			"sequenceEnd": 142,
+			"sequenceChecksum": "6077c452d1dc6151040b2b179e2294c7",
+			"gene": "HBA1",
+			"uniprotAccession": "P69905",
+			"uniprotId": "HBA_HUMAN",
+			"uniprotDescription": "Hemoglobin subunit alpha",
+			"organismScientificName": "Homo sapiens",
+			"entryId": "AF-P69905-F1",
+			"pdbUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.pdb",
+			"cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.cif",
+			"paeDocUrl": "https://alphafold.ebi.ac.uk/files/AF-P69905-F1-predicted_aligned_error_v6.json"
+		}
+	]
 }

--- a/tests/test_alphafold_bulk_metadata.py
+++ b/tests/test_alphafold_bulk_metadata.py
@@ -1,0 +1,117 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+from biomni.tool import database
+from biomni.tool.tool_description import database as database_description
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class Response:
+    def __init__(self, payload=None, *, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Server Error")
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def fixture_payload():
+    return json.loads((FIXTURES_DIR / "alphafold_p69905_prediction.json").read_text(encoding="utf-8"))["response"]
+
+
+def fixture_record():
+    return fixture_payload()[0]
+
+
+def test_normalize_alphafold_uniprot_ids_accepts_string_and_list():
+    assert database._normalize_alphafold_uniprot_ids("P69905, P68871\nP05067") == ["P69905", "P68871", "P05067"]
+    assert database._normalize_alphafold_uniprot_ids(["P69905", " ", "P05067"]) == ["P69905", "P05067"]
+
+
+def test_extract_alphafold_prediction_record_returns_first_list_record():
+    assert database._extract_alphafold_prediction_record(fixture_payload())["uniprotAccession"] == "P69905"
+    assert database._extract_alphafold_prediction_record(fixture_record())["uniprotAccession"] == "P69905"
+    assert database._extract_alphafold_prediction_record([]) == {}
+
+
+def test_format_alphafold_bulk_record_returns_metadata_summary():
+    output = database._format_alphafold_bulk_record("P69905", fixture_record())
+    assert "UniProt ID: P69905" in output
+    assert "Entry ID: AF-P69905-F1" in output
+    assert "Gene: HBA1" in output
+    assert "Description: Hemoglobin subunit alpha" in output
+    assert "Organism: Homo sapiens" in output
+    assert "Sequence Range: 1-142" in output
+    assert "Latest Version: 6" in output
+    assert "Model Created: 2025-08-01T00:00:00Z" in output
+    assert "Sequence Checksum: 6077c452d1dc6151040b2b179e2294c7" in output
+    assert "Mean pLDDT: 98.06" in output
+    assert "PDB URL: https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.pdb" in output
+
+
+def test_format_alphafold_bulk_record_handles_missing_record():
+    output = database._format_alphafold_bulk_record("MISSING", {})
+    assert output == "UniProt ID: MISSING\nStatus: No AlphaFold prediction found."
+
+
+def test_search_alphafold_bulk_metadata_calls_prediction_endpoint():
+    session = Mock()
+    session.get.return_value = Response(fixture_payload())
+    records = database._search_alphafold_bulk_metadata(["P69905"], session=session)
+    assert records[0][0] == "P69905"
+    assert records[0][1]["entryId"] == "AF-P69905-F1"
+    session.get.assert_called_once_with("https://alphafold.ebi.ac.uk/api/prediction/P69905", timeout=30)
+
+
+def test_search_alphafold_bulk_metadata_records_404_as_missing():
+    session = Mock()
+    session.get.return_value = Response({"error": "not found"}, status_code=404)
+    records = database._search_alphafold_bulk_metadata(["MISSING"], session=session)
+    assert records == [("MISSING", {})]
+
+
+def test_query_alphafold_bulk_metadata_returns_formatted_result(monkeypatch):
+    monkeypatch.setattr(database, "_search_alphafold_bulk_metadata", lambda uniprot_ids: [("P69905", fixture_record())])
+    result = database.query_alphafold_bulk_metadata("P69905", max_results=1)
+    assert "UniProt ID: P69905" in result
+    assert "Sequence Checksum: 6077c452d1dc6151040b2b179e2294c7" in result
+
+
+def test_query_alphafold_bulk_metadata_passes_limited_ids(monkeypatch):
+    captured = {}
+
+    def fake_search(uniprot_ids):
+        captured["uniprot_ids"] = uniprot_ids
+        return [("P69905", fixture_record())]
+
+    monkeypatch.setattr(database, "_search_alphafold_bulk_metadata", fake_search)
+    database.query_alphafold_bulk_metadata("P69905,P68871,P05067", max_results=2)
+    assert captured["uniprot_ids"] == ["P69905", "P68871"]
+
+
+def test_query_alphafold_bulk_metadata_rejects_empty_ids():
+    result = database.query_alphafold_bulk_metadata(" , ")
+    assert result == "Error querying AlphaFold bulk metadata: UniProt IDs must not be empty."
+
+
+def test_query_alphafold_bulk_metadata_returns_error_string_on_http_error(monkeypatch):
+    def raise_error(uniprot_ids):
+        raise requests.HTTPError("500 Server Error")
+
+    monkeypatch.setattr(database, "_search_alphafold_bulk_metadata", raise_error)
+    result = database.query_alphafold_bulk_metadata("P69905")
+    assert result == "Error querying AlphaFold bulk metadata: 500 Server Error"
+
+
+def test_alphafold_bulk_metadata_tool_description_is_registered():
+    names = {entry["name"] for entry in database_description.description}
+    assert "query_alphafold_bulk_metadata" in names


### PR DESCRIPTION
This PR adds a new A1-visible database/data tool for bulk AlphaFold Protein Structure Database metadata lookup.

Changes:

adds `query_alphafold_bulk_metadata` to `biomni/tool/database.py`
adds the matching tool description entry in `biomni/tool/tool_description/database.py`
adds focused fixture-backed tests in `tests/test_alphafold_bulk_metadata.py`
adds a reduced public AlphaFold DB prediction fixture in `tests/fixtures/alphafold_p69905_prediction.json`

`query_alphafold_bulk_metadata` accepts a comma-separated string or list of UniProt accessions, queries the existing AlphaFold DB prediction endpoint for each accession, and returns concise metadata including entry ID, gene, organism, model version, model date, sequence checksum, mean pLDDT, and structure/document URLs.

Testing
Focused tests and lint passed:

```bash
python -m pytest tests/test_alphafold_bulk_metadata.py
python -m ruff check biomni/tool/database.py biomni/tool/tool_description/database.py tests/test_alphafold_bulk_metadata.py
```

Result:

```text
11 passed
All checks passed!
```

Manual Live Prompt Validation
Manual local-LLM prompt validation passed against the local OpenAI-compatible Qwen endpoint with A1 tool retrieval enabled.

Prompt:

```text
Use Python to import the Biomni database tool exactly as follows: from biomni.tool.database import query_alphafold_bulk_metadata. Then call query_alphafold_bulk_metadata('P69905,P68871', max_results=2) exactly once and print the result. After the observation, respond with a <solution> that reports each UniProt ID, gene, latest version, sequence checksum, mean pLDDT, and PDB URL. If the observation is an error, report the exact error in the <solution>.
```

Result:

A1 selected `query_alphafold_bulk_metadata`
A1 generated an `<execute>` block
The tool queried live AlphaFold DB prediction metadata
A1 completed with a `<solution>`

Observed tool output:

```text
UniProt ID: P69905
Entry ID: AF-P69905-F1
Gene: HBA1
Description: Hemoglobin subunit alpha
Organism: Homo sapiens
Sequence Range: 1-142
Latest Version: 6
Model Created: 2025-08-01T00:00:00Z
Sequence Checksum: 6077c452d1dc6151040b2b179e2294c7
Mean pLDDT: 98.06
PDB URL: https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.pdb
CIF URL: https://alphafold.ebi.ac.uk/files/AF-P69905-F1-model_v6.cif
PAE JSON URL: https://alphafold.ebi.ac.uk/files/AF-P69905-F1-predicted_aligned_error_v6.json

UniProt ID: P68871
Entry ID: AF-P68871-F1
Gene: HBB
Description: Hemoglobin subunit beta
Organism: Homo sapiens
Sequence Range: 1-147
Latest Version: 6
Model Created: 2025-08-01T00:00:00Z
Sequence Checksum: 209d686939d0b8d1ea089368150140e2
Mean pLDDT: 97.19
PDB URL: https://alphafold.ebi.ac.uk/files/AF-P68871-F1-model_v6.pdb
CIF URL: https://alphafold.ebi.ac.uk/files/AF-P68871-F1-model_v6.cif
PAE JSON URL: https://alphafold.ebi.ac.uk/files/AF-P68871-F1-predicted_aligned_error_v6.json
```

Notes
This follows Biomni's legacy database-tool pattern: the implementation is added directly to `biomni/tool/database.py`, the A1-visible description is added directly to `biomni/tool/tool_description/database.py`, and tests use a local fixture with a mocked response.

This complements the existing single-accession `query_alphafold` function without changing its behavior. It returns metadata and URLs only; it does not download structure files.